### PR TITLE
Resolve and compile refs when inventory is cached

### DIFF
--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -488,9 +488,8 @@ def main():
             check_version()
 
         ref_controller = RefController(args.refs_path)
-        # cache controller for use in reveal_maybe jinja2 filter
         cached.ref_controller_obj = ref_controller
-        cached.revealer_obj = Revealer(ref_controller)
+        cached.revealer_obj = Revealer(ref_controller, reveal=args.reveal, targets=args.targets)
 
         compile_targets(
             args.inventory_path,
@@ -499,10 +498,8 @@ def main():
             args.parallelism,
             args.targets,
             args.labels,
-            ref_controller,
             prune=(args.prune),
             indent=args.indent,
-            reveal=args.reveal,
             cache=args.cache,
             cache_paths=args.cache_paths,
             fetch_dependencies=args.fetch,

--- a/kapitan/inputs/copy.py
+++ b/kapitan/inputs/copy.py
@@ -15,8 +15,8 @@ logger = logging.getLogger(__name__)
 
 
 class Copy(InputType):
-    def __init__(self, compile_path, search_paths, ref_controller):
-        super().__init__("copy", compile_path, search_paths, ref_controller)
+    def __init__(self, compile_path, search_paths):
+        super().__init__("copy", compile_path, search_paths)
 
     def compile_file(self, file_path, compile_path, ext_vars, **kwargs):
         """

--- a/kapitan/inputs/helm/__init__.py
+++ b/kapitan/inputs/helm/__init__.py
@@ -15,8 +15,8 @@ logger = logging.getLogger(__name__)
 
 
 class Helm(InputType):
-    def __init__(self, compile_path, search_paths, ref_controller):
-        super().__init__("helm", compile_path, search_paths, ref_controller)
+    def __init__(self, compile_path, search_paths):
+        super().__init__("helm", compile_path, search_paths)
         self.helm_values_file = None
         self.helm_params = {}
         self.lib = self.initialise_binding()
@@ -51,18 +51,12 @@ class Helm(InputType):
         """
         Render templates in file_path/templates and write to compile_path.
         file_path must be a directory containing helm chart.
-        kwargs:
-            reveal: default False, set to reveal refs on compile
-            target_name: default None, set to current target being compiled
         """
         if not self.lib:
             raise HelmBindingUnavailableError(
                 "Helm binding is not supported for {}."
                 "\nOr the binding does not exist.".format(platform.system())
             )
-
-        reveal = kwargs.get("reveal", False)
-        target_name = kwargs.get("target_name", None)
 
         temp_dir = tempfile.mkdtemp()
         os.makedirs(os.path.dirname(compile_path), exist_ok=True)
@@ -85,9 +79,7 @@ class Helm(InputType):
                 with open(full_file_name, "r") as f:
                     item_path = os.path.join(compile_path, rel_file_name)
                     os.makedirs(os.path.dirname(item_path), exist_ok=True)
-                    with CompiledFile(
-                        item_path, self.ref_controller, mode="w", reveal=reveal, target_name=target_name
-                    ) as fp:
+                    with CompiledFile(item_path, mode="w") as fp:
                         yml_obj = list(yaml.safe_load_all(f))
                         fp.write_yaml(yml_obj)
                         logger.debug("Wrote file %s to %s", full_file_name, item_path)

--- a/kapitan/inputs/jinja2.py
+++ b/kapitan/inputs/jinja2.py
@@ -16,18 +16,16 @@ logger = logging.getLogger(__name__)
 
 
 class Jinja2(InputType):
-    def __init__(self, compile_path, search_paths, ref_controller):
-        super().__init__("jinja2", compile_path, search_paths, ref_controller)
+    def __init__(self, compile_path, search_paths):
+        super().__init__("jinja2", compile_path, search_paths)
 
     def compile_file(self, file_path, compile_path, ext_vars, **kwargs):
         """
         Write items in path as jinja2 rendered files to compile_path.
         path can be either a file or directory.
         kwargs:
-            reveal: default False, set to reveal refs on compile
             target_name: default None, set to current target being compiled
         """
-        reveal = kwargs.get("reveal", False)
         target_name = kwargs.get("target_name", None)
 
         # set ext_vars and inventory for jinja2 context
@@ -39,9 +37,7 @@ class Jinja2(InputType):
         for item_key, item_value in render_jinja2(file_path, context, jinja2_filters=jinja2_filters).items():
             full_item_path = os.path.join(compile_path, item_key)
 
-            with CompiledFile(
-                full_item_path, self.ref_controller, mode="w", reveal=reveal, target_name=target_name
-            ) as fp:
+            with CompiledFile(full_item_path, mode="w") as fp:
                 fp.write(item_value["content"])
                 mode = item_value["mode"]
                 os.chmod(full_item_path, mode)

--- a/kapitan/inputs/jsonnet.py
+++ b/kapitan/inputs/jsonnet.py
@@ -17,8 +17,8 @@ logger = logging.getLogger(__name__)
 
 
 class Jsonnet(InputType):
-    def __init__(self, compile_path, search_paths, ref_controller):
-        super().__init__("jsonnet", compile_path, search_paths, ref_controller)
+    def __init__(self, compile_path, search_paths):
+        super().__init__("jsonnet", compile_path, search_paths)
 
     def compile_file(self, file_path, compile_path, ext_vars, **kwargs):
         """
@@ -27,8 +27,6 @@ class Jsonnet(InputType):
         kwargs:
             output: default 'yaml', accepts 'json'
             prune: default False, accepts True
-            reveal: default False, set to reveal refs on compile
-            target_name: default None, set to current target being compiled
             indent: default 2
         """
 
@@ -45,8 +43,6 @@ class Jsonnet(InputType):
 
         output = kwargs.get("output", "yaml")
         prune = kwargs.get("prune_input", False)
-        reveal = kwargs.get("reveal", False)
-        target_name = kwargs.get("target_name", None)
         indent = kwargs.get("indent", 2)
 
         if prune:
@@ -65,36 +61,15 @@ class Jsonnet(InputType):
             # write each item to disk
             if output == "json":
                 file_path = os.path.join(compile_path, "%s.%s" % (item_key, output))
-                with CompiledFile(
-                    file_path,
-                    self.ref_controller,
-                    mode="w",
-                    reveal=reveal,
-                    target_name=target_name,
-                    indent=indent,
-                ) as fp:
+                with CompiledFile(file_path, mode="w", indent=indent) as fp:
                     fp.write_json(item_value)
             elif output == "yaml":
                 file_path = os.path.join(compile_path, "%s.%s" % (item_key, "yml"))
-                with CompiledFile(
-                    file_path,
-                    self.ref_controller,
-                    mode="w",
-                    reveal=reveal,
-                    target_name=target_name,
-                    indent=indent,
-                ) as fp:
+                with CompiledFile(file_path, mode="w", indent=indent) as fp:
                     fp.write_yaml(item_value)
             elif output == "plain":
                 file_path = os.path.join(compile_path, "%s" % item_key)
-                with CompiledFile(
-                    file_path,
-                    self.ref_controller,
-                    mode="w",
-                    reveal=reveal,
-                    target_name=target_name,
-                    indent=indent,
-                ) as fp:
+                with CompiledFile(file_path, mode="w", indent=indent) as fp:
                     fp.write(item_value)
             else:
                 raise ValueError(

--- a/kapitan/inputs/kadet.py
+++ b/kapitan/inputs/kadet.py
@@ -66,8 +66,8 @@ def load_from_search_paths(module_name):
 
 
 class Kadet(InputType):
-    def __init__(self, compile_path, search_paths, ref_controller):
-        super().__init__("kadet", compile_path, search_paths, ref_controller)
+    def __init__(self, compile_path, search_paths):
+        super().__init__("kadet", compile_path, search_paths)
 
     def compile_file(self, file_path, compile_path, ext_vars, **kwargs):
         """
@@ -76,13 +76,11 @@ class Kadet(InputType):
         kwargs:
             output: default 'yaml', accepts 'json'
             prune: default False
-            reveal: default False, set to reveal refs on compile
             target_name: default None, set to current target being compiled
             indent: default 2
         """
         output = kwargs.get("output", "yaml")
-        prune = kwargs.get("prune", False)
-        reveal = kwargs.get("reveal", False)
+        prune = kwargs.get("prune_input", False)
         target_name = kwargs.get("target_name", None)
         indent = kwargs.get("indent", 2)
 
@@ -108,36 +106,15 @@ class Kadet(InputType):
             # write each item to disk
             if output == "json":
                 file_path = os.path.join(compile_path, "%s.%s" % (item_key, output))
-                with CompiledFile(
-                    file_path,
-                    self.ref_controller,
-                    mode="w",
-                    reveal=reveal,
-                    target_name=target_name,
-                    indent=indent,
-                ) as fp:
+                with CompiledFile(file_path, mode="w", indent=indent) as fp:
                     fp.write_json(item_value)
             elif output == "yaml":
                 file_path = os.path.join(compile_path, "%s.%s" % (item_key, "yml"))
-                with CompiledFile(
-                    file_path,
-                    self.ref_controller,
-                    mode="w",
-                    reveal=reveal,
-                    target_name=target_name,
-                    indent=indent,
-                ) as fp:
+                with CompiledFile(file_path, mode="w", indent=indent) as fp:
                     fp.write_yaml(item_value)
             elif output == "plain":
                 file_path = os.path.join(compile_path, "%s" % item_key)
-                with CompiledFile(
-                    file_path,
-                    self.ref_controller,
-                    mode="w",
-                    reveal=reveal,
-                    target_name=target_name,
-                    indent=indent,
-                ) as fp:
+                with CompiledFile(file_path, mode="w", indent=indent) as fp:
                     fp.write(item_value)
             else:
                 raise ValueError(

--- a/kapitan/refs/base.py
+++ b/kapitan/refs/base.py
@@ -147,10 +147,12 @@ class PlainRefBackend(object):
 
 
 class Revealer(object):
-    def __init__(self, ref_controller):
+    def __init__(self, ref_controller, **kwargs):
         "reveal files and objects"
         self.ref_controller = ref_controller
         self.regex = re.compile(REF_TOKEN_TAG_PATTERN)
+        self.reveal = kwargs.get("reveal", False)
+        self.targets = kwargs.get("targets", None)
 
     def reveal_path(self, path):
         "detects if path is file or dir, returns list of RevealObj"

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -7,7 +7,6 @@
 
 from __future__ import print_function
 
-import collections
 import json
 import logging
 import math
@@ -15,6 +14,7 @@ import os
 import stat
 import sys
 from collections import Counter, defaultdict
+from collections.abc import MutableMapping
 from functools import lru_cache, wraps
 from hashlib import sha256
 
@@ -208,7 +208,7 @@ def flatten_dict(d, parent_key="", sep="."):
     items = []
     for k, v in d.items():
         new_key = parent_key + sep + k if parent_key else k
-        if isinstance(v, collections.MutableMapping):
+        if isinstance(v, MutableMapping):
             items.extend(flatten_dict(v, new_key, sep=sep).items())
         else:
             items.append((new_key, v))

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -18,7 +18,6 @@ from kapitan.inputs.copy import Copy
 
 
 search_path = ""
-ref_controller = ""
 test_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_copy")
 compile_path = os.path.join(test_path, "output")
 file_path = os.path.join(test_path, "input")
@@ -57,7 +56,7 @@ class CopyTest(unittest.TestCase):
         except FileNotFoundError:
             pass
 
-        self.copy_compiler = Copy(compile_path, search_path, ref_controller)
+        self.copy_compiler = Copy(compile_path, search_path)
 
     def test_copy_file_folder(self):
         test_dirs_bootstrap_helper()

--- a/tests/test_helm_input.py
+++ b/tests/test_helm_input.py
@@ -33,7 +33,7 @@ class HelmInputTest(unittest.TestCase):
     def test_render_chart(self):
         temp_dir = tempfile.mkdtemp()
         chart_path = "charts/acs-engine-autoscaler"
-        helm = Helm(None, None, None)
+        helm = Helm(None, None)
         error_message = helm.render_chart(chart_path, temp_dir)
         self.assertFalse(error_message)
         self.assertTrue(
@@ -46,7 +46,7 @@ class HelmInputTest(unittest.TestCase):
     def test_error_invalid_char_dir(self):
         chart_path = "non-existent"
         temp_dir = tempfile.mkdtemp()
-        helm = Helm(None, None, None)
+        helm = Helm(None, None)
         error_message = helm.render_chart(chart_path, temp_dir)
         self.assertTrue("no such file or directory" in error_message)
 


### PR DESCRIPTION
Signed-off-by: Trevor Wood <Trevor.G.Wood@gmail.com>

Fixes issue #341. 

## Proposed Changes

* Resolves and compiles all refs when the inventory is cached rather than doing a find and replace in the final compiled files. 