### PR TITLE
added fire for automatic cli generation

### DIFF
--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -55,6 +55,20 @@ def fatal_error(message):
     sys.exit(1)
 
 
+def parse_arg_delimiter(arg_value, delimiter, is_a_path=False):
+    """
+    If parsed as string then returns list of string delimited by delimiter
+    else just returns passed arg_value
+    """
+    if isinstance(arg_value, str):
+        if is_a_path:
+            return [os.path.abspath(path) for path in arg_value.split(delimiter)]
+        else:
+            return [item for item in arg_value.split(delimiter)]
+
+    return arg_value
+
+
 def hashable_lru_cache(func):
     """Usable instead of lru_cache for functions using unhashable objects"""
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,6 @@ yamllint>=1.15.0
 cffi
 rfc3987==1.3.8
 GitPython==2.1.11
+fire==0.2.1
 # Reclass dependencies
 pyparsing

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -398,7 +398,7 @@ class CliFuncsTest(unittest.TestCase):
         """
         run $ kapitan inventory -t minikube-es -F -p cluster
         """
-        sys.argv = ["kapitan", "inventory", "-t", "minikube-es", "-F", "-p", "cluster",
+        sys.argv = ["kapitan", "inventory", "-t", "minikube-es", "-f", "-p", "cluster",
                     "--inventory-path", "examples/kubernetes/inventory/"]
 
         # set stdout as string

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -34,7 +34,7 @@ class CompileKubernetesTest(unittest.TestCase):
         os.chdir(os.getcwd() + '/examples/kubernetes/')
 
     def test_compile(self):
-        sys.argv = ["kapitan", "compile", "-c"]
+        sys.argv = ["kapitan", "compile", "-cache"]
         main()
         os.remove('./compiled/.kapitan_cache')
         compiled_dir_hash = directory_hash(os.getcwd() + '/compiled')

--- a/tests/test_dependency_manager.py
+++ b/tests/test_dependency_manager.py
@@ -65,7 +65,7 @@ class DependencyManagerTest(unittest.TestCase):
         temp = tempfile.mkdtemp()
         DEPENDENCY_OUTPUT_CONFIG["root_dir"] = temp
         sys.argv = ["kapitan", "compile", "--fetch", "--output-path", temp, "-t",
-                    "nginx", "nginx-dev", "-p", "4"]
+                    "nginx,nginx-dev", "--parallelism", "4"]
         main()
         self.assertTrue(os.path.isdir(os.path.join(temp, "components", "tests")))
         self.assertTrue(os.path.isdir(os.path.join(temp, "components", "acs-engine-autoscaler")))

--- a/tests/test_helm_input.py
+++ b/tests/test_helm_input.py
@@ -70,7 +70,7 @@ class HelmInputTest(unittest.TestCase):
     def test_compile_multiple_targets(self):
         temp = tempfile.mkdtemp()
         sys.argv = ["kapitan", "compile", "--output-path", temp,
-                    "-t", "acs-engine-autoscaler", "nginx-ingress", "--parallelism", "2"]
+                    "-t", "acs-engine-autoscaler,nginx-ingress", "--parallelism", "2"]
         main()
         self.assertTrue(os.path.isfile(
             os.path.join(temp, "compiled", "acs-engine-autoscaler", "acs-engine-autoscaler",

--- a/tests/test_helm_input.py
+++ b/tests/test_helm_input.py
@@ -70,7 +70,7 @@ class HelmInputTest(unittest.TestCase):
     def test_compile_multiple_targets(self):
         temp = tempfile.mkdtemp()
         sys.argv = ["kapitan", "compile", "--output-path", temp,
-                    "-t", "acs-engine-autoscaler", "nginx-ingress", "-p", "2"]
+                    "-t", "acs-engine-autoscaler", "nginx-ingress", "--parallelism", "2"]
         main()
         self.assertTrue(os.path.isfile(
             os.path.join(temp, "compiled", "acs-engine-autoscaler", "acs-engine-autoscaler",


### PR DESCRIPTION
Fixes issue https://github.com/deepmind/kapitan/issues/240 

## Proposed Changes

  - Use fire for automatic CLI generation
  - paths will have to be passed comma separated now
  - kapitan --help will work now 
  - shorthand notation supported, eg. for an argument named recursive, --recursive, -recursive and -r works. Note that -r works smooth if there is no other parameter starting with r else fire will show both options to user. Capital (-R) is not supported.

Note that only those flags are updated which have same first letter in their argument name, like prune and parallelism in compile. Another change is passing comma separated paths. 

Although updating tests in never a good idea but still some changes had to be made due to change in way of using CLI after this update.