### PR TITLE
[WIP] Add CLI option to select custom targets path

### DIFF
--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -168,6 +168,11 @@ def main():
         help='set inventory path, default is "./inventory"',
     )
     compile_parser.add_argument(
+        "--targets-path",
+        default=from_dot_kapitan("compile", "targets-path", "./inventory/targets"),
+        help='set targets path, default is "./inventory/targets"',
+    )
+    compile_parser.add_argument(
         "--cache",
         "-c",
         help="enable compilation caching to .kapitan_cache, default is False",
@@ -417,6 +422,11 @@ def main():
         help='set inventory path, default is "./inventory"',
     )
     validate_parser.add_argument(
+        "--targets-path",
+        default=from_dot_kapitan("compile", "targets-path", "./inventory/targets"),
+        help='set targets path, default is "./inventory/targets"',
+    )
+    validate_parser.add_argument(
         "--targets",
         "-t",
         help="targets to validate, default is all",
@@ -494,6 +504,7 @@ def main():
 
         compile_targets(
             args.inventory_path,
+            args.targets_path,
             search_paths,
             args.output_path,
             args.parallelism,
@@ -568,6 +579,7 @@ def main():
         schema_validate_compiled(
             args.targets,
             inventory_path=args.inventory_path,
+            targets_path=args.targets_path,
             compiled_path=args.compiled_path,
             schema_cache_path=args.schemas_path,
             parallel=args.parallelism,

--- a/kapitan/resources.py
+++ b/kapitan/resources.py
@@ -231,7 +231,7 @@ def inventory(search_paths, target, inventory_path="inventory/"):
     return inventory_reclass(full_inv_path)["nodes"][target]
 
 
-def inventory_reclass(inventory_path):
+def inventory_reclass(inventory_path, targets_path=None):
     """
     Runs a reclass inventory in inventory_path
     (same output as running ./reclass.py -b inv_base_uri/ --inventory)
@@ -240,11 +240,14 @@ def inventory_reclass(inventory_path):
     Returns a reclass style dictionary
     """
 
+    if not targets_path:
+        targets_path = os.path.join(inventory_path, "targets")
+
     if not cached.inv:
         reclass_config = {
             "storage_type": "yaml_fs",
             "inventory_base_uri": inventory_path,
-            "nodes_uri": os.path.join(inventory_path, "targets"),
+            "nodes_uri": targets_path,
             "classes_uri": os.path.join(inventory_path, "classes"),
             "compose_node_name": False,
         }


### PR DESCRIPTION
Fixes issue #275 

## Proposed Changes

  - Add CLI flag to add custom targets path
  - Expand the path and save it as a reclass object

There is only one problem that I am facing:
`kapitan/lib/kapitan.libjsonnet` has this
```
  inventory(target=std.extVar("target"), inv_path="inventory/"):: std.native("inventory")(target, inv_path),
```
hardcoded. So is there a way to override this when dealing with custom target paths?
@uberspot 
