### PR TITLE
macOS kapitan release proposal

### DIFF
--- a/docs/kap_proposals/kap_8_helm_binding_MacOS.md
+++ b/docs/kap_proposals/kap_8_helm_binding_MacOS.md
@@ -1,0 +1,31 @@
+#  macOS release
+
+This task can be divided into 3 parts.
+
+- Complete the Helm binding pipeline so that TravisCI also builds binding for osx and releases them to GitHub release.
+
+- Packaging the binding to the pypi release.
+
+- Add a brew formula for kapitan
+
+## 1. Helm binding pipeline
+Build 2 separate versions of shared object (.so) file depending on the platform.
+This can be achieved as Travis supports builds on multiple platforms.
+
+## 2. PYPI packaging
+The packaging can be incorporated in the travis pipeline by adding a ​travis_wait​ argument ​to the ​`.travis.yml`​ file so that the packaging happens after the build. Users can then simply install kapitan using pip which installs wheels compatible with the running platform.
+
+## 3. Brew packaging
+Create a formula for kapitan using `$ brew create <url>` and configure the formula using the [Formula API](https://rubydoc.brew.sh/Formula)
+
+- Create and maintain a tap for the formula.
+    * A tap has to be a GitHub repository starting with "Homebrew-"
+    * We can either [https://github.com/deepmind] or [https://github.com/kapicorp] to host the tap
+    * It has to be manually updated with PRs for every kapitan release
+
+- This will enable the users to install kapitan on MacOS using the following commands:
+```shell
+$ brew tap kapicorp/kapitan
+$ brew install kapitan
+```
+


### PR DESCRIPTION
Related to issue #368 and #274 

## Issues with making the helm binding pipeline for macOS
- What works:
   * The .so file is generated without any error 
   * Individual helm unittests run without any error
- What doesn't work:
   * While trying to run all the unittests together, the program gets stuck with `fatal: morestack g0`error message
   * Upon searching the issue up, It seems to be a prevailing [kernel issue for macOS](https://github.com/golang/go/issues/39457)
   * Currently, I'm trying to find a workaround by changing the stack size
## My environment 
OS: macOS 10.15.5
```shell
$ go version
go version go1.14.5 darwin/amd64
```
```shell
$ python3 --version
Python 3.7.7
```
<details>
<summary>

`$ go env`
</summary>

```shell
GO111MODULE=""
GOARCH="amd64"
GOBIN=""
GOCACHE="/Users/roy/Library/Caches/go-build"
GOENV="/Users/roy/Library/Application Support/go/env"
GOEXE=""
GOFLAGS=""
GOHOSTARCH="amd64"
GOHOSTOS="darwin"
GOINSECURE=""
GONOPROXY=""
GONOSUMDB=""
GOOS="darwin"
GOPATH="/Users/roy/go"
GOPRIVATE=""
GOPROXY="https://proxy.golang.org,direct"
GOROOT="/usr/local/Cellar/go/1.14.5/libexec"
GOSUMDB="sum.golang.org"
GOTMPDIR=""
GOTOOLDIR="/usr/local/Cellar/go/1.14.5/libexec/pkg/tool/darwin_amd64"
GCCGO="gccgo"
AR="ar"
CC="clang"
CXX="clang++"
CGO_ENABLED="1"
GOMOD=""
CGO_CFLAGS="-g -O2"
CGO_CPPFLAGS="-Wno-error -Wno-nullability-completeness -Wno-expansion-to-defined -Wno-builtin-requires-header"
CGO_CXXFLAGS="-I/usr/local/opt/libjpeg/include -I/usr/local/opt/libpng/include -I/usr/local/opt/libtiff/include -Dcimg_no_system_calls"
CGO_FFLAGS="-g -O2"
CGO_LDFLAGS="-L/usr/local/opt/libjpeg/lib -L/usr/local/opt/libpng/lib -L/usr/local/opt/libtiff/lib"
PKG_CONFIG="pkg-config"
GOGCCFLAGS="-fPIC -m64 -pthread -fno-caret-diagnostics -Qunused-arguments -fmessage-length=0 -fdebug-prefix-map=/var/folders/t0/zssh__gn7pq9hgwc4rd5r5jm0000gn/T/go-build805186882=/tmp/go-build -gno-record-gcc-switches -fno-common"
```
</details>
