### PR TITLE
Ignore copy file on missing source

### DIFF
--- a/docs/compile.md
+++ b/docs/compile.md
@@ -456,6 +456,18 @@ For Copy, `input_paths` can be either a file or a directory: in case of a direct
 
 *Supported output types*: N/A (no need to specify `output_type`)
 
+Example
+
+```yaml
+ kapitan:
+    compile:
+      - input_type: copy
+        ignore_missing: true  # Do not error if path is missing. Defaults to False
+        input_paths:
+          - resources/state/${target_name}/.terraform.lock.hcl
+        output_path: terraform/
+```
+
 ### Remove
 
 This input type simply removes files or directories. This can be helpful if you can't control particular files

--- a/kapitan/inputs/base.py
+++ b/kapitan/inputs/base.py
@@ -44,7 +44,7 @@ class InputType(object):
             # remove duplicate inputs
             inputs = set(inputs)
             ignore_missing = comp_obj.get("ignore_missing", False)
-            if len(inputs) == 0 and ignore_missing == False:
+            if len(inputs) == 0 and not ignore_missing:
                 raise CompileError(
                     "Compile error: {} for target: {} not found in "
                     "search_paths: {}".format(input_path, ext_vars["target"], self.search_paths)

--- a/kapitan/inputs/base.py
+++ b/kapitan/inputs/base.py
@@ -43,7 +43,8 @@ class InputType(object):
             inputs = list(itertools.chain.from_iterable(globbed_paths))
             # remove duplicate inputs
             inputs = set(inputs)
-            if len(inputs) == 0:
+            ignore_missing = comp_obj.get("ignore_missing", False)
+            if len(inputs) == 0 and ignore_missing == False:
                 raise CompileError(
                     "Compile error: {} for target: {} not found in "
                     "search_paths: {}".format(input_path, ext_vars["target"], self.search_paths)

--- a/kapitan/inputs/copy.py
+++ b/kapitan/inputs/copy.py
@@ -36,15 +36,12 @@ class Copy(InputType):
                         shutil.copy2(file_path, compile_path)
                     else:
                         os.makedirs(compile_path, exist_ok=True)
-                        shutil.copy2(file_path, os.path.join(
-                            compile_path, os.path.basename(file_path)))
+                        shutil.copy2(file_path, os.path.join(compile_path, os.path.basename(file_path)))
                 else:
-                    compile_path = os.path.abspath(
-                        compile_path)  # Resolve relative paths
+                    compile_path = os.path.abspath(compile_path)  # Resolve relative paths
                     copy_tree(file_path, compile_path)
             elif ignore_missing == False:
-                raise OSError(
-                    f"Path {file_path} does not exist and `ignore_missing` is {ignore_missing}")
+                raise OSError(f"Path {file_path} does not exist and `ignore_missing` is {ignore_missing}")
         except OSError as e:
             logger.exception(f"Input dir not copied. Error: {e}")
 

--- a/kapitan/inputs/copy.py
+++ b/kapitan/inputs/copy.py
@@ -16,7 +16,8 @@ logger = logging.getLogger(__name__)
 
 
 class Copy(InputType):
-    def __init__(self, compile_path, search_paths, ref_controller):
+    def __init__(self, compile_path, search_paths, ref_controller, ignore_missing=False):
+        self.ignore_missing = ignore_missing
         super().__init__("copy", compile_path, search_paths, ref_controller)
 
     def compile_file(self, file_path, compile_path, ext_vars, **kwargs):
@@ -25,17 +26,25 @@ class Copy(InputType):
         path can be either a file or directory.
         """
 
+        # Whether to fail silently if the path does not exists.
+        ignore_missing = self.ignore_missing
         try:
             logger.debug("Copying {} to {}.".format(file_path, compile_path))
-            if os.path.isfile(file_path):
-                if os.path.isfile(compile_path):
-                    shutil.copy2(file_path, compile_path)
+            if os.path.exists(file_path):
+                if os.path.isfile(file_path):
+                    if os.path.isfile(compile_path):
+                        shutil.copy2(file_path, compile_path)
+                    else:
+                        os.makedirs(compile_path, exist_ok=True)
+                        shutil.copy2(file_path, os.path.join(
+                            compile_path, os.path.basename(file_path)))
                 else:
-                    os.makedirs(compile_path, exist_ok=True)
-                    shutil.copy2(file_path, os.path.join(compile_path, os.path.basename(file_path)))
-            else:
-                compile_path = os.path.abspath(compile_path)  # Resolve relative paths
-                copy_tree(file_path, compile_path)
+                    compile_path = os.path.abspath(
+                        compile_path)  # Resolve relative paths
+                    copy_tree(file_path, compile_path)
+            elif ignore_missing == False:
+                raise OSError(
+                    f"Path {file_path} does not exist and `ignore_missing` is {ignore_missing}")
         except OSError as e:
             logger.exception(f"Input dir not copied. Error: {e}")
 

--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -448,7 +448,8 @@ def compile_target(target_obj, search_paths, compile_path, ref_controller, **kwa
             if "kube_version" in comp_obj:
                 input_compiler.set_kube_version(comp_obj["kube_version"])
         elif input_type == "copy":
-            input_compiler = Copy(compile_path, search_paths, ref_controller)
+            ignore_missing = comp_obj.get("ignore_missing", False)
+            input_compiler = Copy(compile_path, search_paths, ref_controller, ignore_missing)
         elif input_type == "remove":
             input_compiler = Remove(compile_path, search_paths, ref_controller)
         elif input_type == "external":

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -23,6 +23,7 @@ test_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_copy"
 compile_path = os.path.join(test_path, "output")
 file_path = os.path.join(test_path, "input")
 test_file_path = os.path.join(file_path, "test_copy_input")
+test_file_missing_path = os.path.join(file_path, "test_copy_input_missing")
 test_file_compiled_path = os.path.join(compile_path, "test_copy_input")
 test_file_content = """
 apiVersion: v1
@@ -80,6 +81,24 @@ class CopyTest(unittest.TestCase):
         except FileNotFoundError:
             pass
 
+class CopyMissingFileTest(unittest.TestCase):
+    def setUp(self):
+        try:
+            shutil.rmtree(test_path)
+        except FileNotFoundError:
+            pass
+
+        self.copy_compiler = Copy(compile_path, search_path, ref_controller, ignore_missing=True)
+
+    def test_copy_missing_path_folder(self):
+        test_dirs_bootstrap_helper()
+        self.copy_compiler.compile_file(test_file_missing_path, compile_path, None)
+
+    def tearDown(self):
+        try:
+            shutil.rmtree(test_path)
+        except FileNotFoundError:
+            pass
 
 class CompileCopyTest(unittest.TestCase):
     def setUp(self):

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -81,6 +81,7 @@ class CopyTest(unittest.TestCase):
         except FileNotFoundError:
             pass
 
+
 class CopyMissingFileTest(unittest.TestCase):
     def setUp(self):
         try:
@@ -99,6 +100,7 @@ class CopyMissingFileTest(unittest.TestCase):
             shutil.rmtree(test_path)
         except FileNotFoundError:
             pass
+
 
 class CompileCopyTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Fixes issue #688

## Proposed Changes

Allows the "copy" input type to continue even if the source path is missing. 

The main motivation behins this change is to enable a workaround to handle terraform lock files which are now being produced when running terraform init, see https://github.com/hashicorp/terraform/issues/27241 

The solution would be to allow adding the following copy settings:
```
 kapitan:
    compile:
      - input_type: copy
        ignore_missing: true
        input_paths:
          - resources/state/${target_name}/.terraform.lock.hcl
        output_path: terraform/
```

Without this feature, the compile process would fail for all new environments where the state file has not already been placed in the state folder.