### PR TITLE
Let the logger format the message lazily.

### DIFF
--- a/kapitan/initialiser.py
+++ b/kapitan/initialiser.py
@@ -25,11 +25,11 @@ def initialise_skeleton(args):
 
     copy_tree(templates_directory, args.directory)
 
-    logger.info("Populated {} with:".format(args.directory))
+    logger.info("Populated %s with:", args.directory)
     for dirName, subdirList, fileList in os.walk(args.directory):
-        logger.info("{}".format(dirName))
+        logger.info("%s", dirName)
         for fname in fileList:
-            logger.info("\t {}".format(fname))
+            logger.info("\t %s", fname)
         # Remove the first entry in the list of sub-directories
         # if there are any sub-directories present
         if len(subdirList) > 0:

--- a/kapitan/inputs/copy.py
+++ b/kapitan/inputs/copy.py
@@ -29,7 +29,7 @@ class Copy(InputType):
         # Whether to fail silently if the path does not exists.
         ignore_missing = self.ignore_missing
         try:
-            logger.debug("Copying {} to {}.".format(file_path, compile_path))
+            logger.debug("Copying %s to %s.", file_path, compile_path)
             if os.path.exists(file_path):
                 if os.path.isfile(file_path):
                     if os.path.isfile(compile_path):
@@ -43,7 +43,7 @@ class Copy(InputType):
             elif ignore_missing == False:
                 raise OSError(f"Path {file_path} does not exist and `ignore_missing` is {ignore_missing}")
         except OSError as e:
-            logger.exception(f"Input dir not copied. Error: {e}")
+            logger.exception("Input dir not copied. Error: %s", e)
 
     def default_output_type(self):
         # no output_type options for copy

--- a/kapitan/inputs/external.py
+++ b/kapitan/inputs/external.py
@@ -47,9 +47,7 @@ class External(InputType):
             # compile_path (str): Path to current target compiled directory
             args = re.sub(r"(\${compiled_target_dir})", compile_path, args)
 
-            logger.debug(
-                "Executing external input with command '{}' and env vars '{}'.".format(args, self.env_vars)
-            )
+            logger.debug("Executing external input with command '%s' and env vars '%s'.", args, self.env_vars)
 
             external_result = subprocess.run(
                 args,
@@ -60,7 +58,7 @@ class External(InputType):
                 encoding="utf8",
             )
 
-            logger.debug("External stdout: {}.".format(external_result.stdout))
+            logger.debug("External stdout: %s.", external_result.stdout)
             if external_result.returncode != 0:
                 raise ValueError(
                     "Executing external input with command '{}' and env vars '{}' failed: {}".format(
@@ -69,7 +67,7 @@ class External(InputType):
                 )
 
         except OSError as e:
-            logger.exception(f"External failed to run. Error: {e}")
+            logger.exception("External failed to run. Error: %s", e)
 
     def default_output_type(self):
         # no output_type options for external

--- a/kapitan/inputs/helm/__init__.py
+++ b/kapitan/inputs/helm/__init__.py
@@ -31,7 +31,7 @@ class Helm(InputType):
         # binding_path is kapitan/inputs/helm/libtemplate.so
         binding_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "libtemplate.so")
         if not os.path.exists(binding_path):
-            logger.debug("The helm binding does not exist at {}".format(binding_path))
+            logger.debug("The helm binding does not exist at %s", binding_path)
             return None
         try:
             lib = ffi.dlopen(binding_path)

--- a/kapitan/inputs/jinja2_filters.py
+++ b/kapitan/inputs/jinja2_filters.py
@@ -57,11 +57,11 @@ def load_module_from_path(env, path):
         custom_filter_spec.loader.exec_module(custom_filter_module)
         for function in dir(custom_filter_module):
             if isinstance(getattr(custom_filter_module, function), types.FunctionType):
-                logger.debug("custom filter loaded from {}".format(path))
+                logger.debug("custom filter loaded from %s", path)
                 env.filters[function] = getattr(custom_filter_module, function)
     except Exception as e:
-        logger.debug("failed to find custom filter from path {}".format(path))
         raise IOError("jinja2 failed to render, could not load filter at {}: {}".format(path, e))
+        logger.debug("failed to find custom filter from path %s", path)
 
 
 def load_jinja2_filters_from_file(env, jinja2_filters):

--- a/kapitan/inputs/kadet.py
+++ b/kapitan/inputs/kadet.py
@@ -114,7 +114,7 @@ class Kadet(InputType):
         logger.debug("Kadet.compile_file: spec.name: %s", spec.name)
 
         kadet_arg_spec = inspect.getfullargspec(kadet_module.main)
-        logger.debug("Kadet main args: {}".format(kadet_arg_spec.args))
+        logger.debug("Kadet main args: %s", kadet_arg_spec.args)
 
         if len(kadet_arg_spec.args) == 1:
             output_obj = kadet_module.main(input_params).to_dict()

--- a/kapitan/inputs/remove.py
+++ b/kapitan/inputs/remove.py
@@ -26,13 +26,13 @@ class Remove(InputType):
         """
 
         try:
-            logger.debug("Removing {}".format(file_path))
+            logger.debug("Removing %s", file_path)
             if os.path.isfile(file_path):
                 os.remove(file_path)
             else:
                 shutil.rmtree(file_path)
         except OSError as e:
-            logger.exception(f"Input dir not removed. Error: {e}")
+            logger.exception("Input dir not removed. Error: %s", e)
 
     def default_output_type(self):
         # no output_type options for remove

--- a/kapitan/lint.py
+++ b/kapitan/lint.py
@@ -101,15 +101,15 @@ def lint_orphan_secrets(compiled_path, secrets_path):
     Yields:
         checks_sum (int): the number of orphan secrets found
     """
-    logger.debug("Find secret paths for " + secrets_path)
+    logger.debug("Find secret paths for %s", secrets_path)
     secrets_paths = set()
     for path in list_all_paths(secrets_path):
         if os.path.isfile(path):
             path = path[len(secrets_path) + 1 :]
             secrets_paths.add(path)
 
-    logger.debug("Collected # of paths: {}".format(len(secrets_paths)))
-    logger.debug("Checking if all secrets are declared in " + compiled_path)
+    logger.debug("Collected # of paths: %s", len(secrets_paths))
+    logger.debug("Checking if all secrets are declared in %s", compiled_path)
 
     for path in list_all_paths(compiled_path):
         if os.path.isfile(path):
@@ -122,9 +122,9 @@ def lint_orphan_secrets(compiled_path, secrets_path):
     checks_sum = len(secrets_paths)
     if checks_sum > 0:
         logger.info(
-            "No usage found for the following {} secrets files:\n{}\n".format(
-                len(secrets_paths), pformat(secrets_paths)
-            )
+            "No usage found for the following %s secrets files:\n%s\n",
+            len(secrets_paths),
+            pformat(secrets_paths),
         )
 
     return checks_sum
@@ -144,7 +144,7 @@ def lint_unused_classes(inventory_path):
     if not os.path.isdir(classes_dir):
         raise KapitanError("{} is not a valid directory or does not exist".format(classes_dir))
 
-    logger.debug("Find unused classes from {}".format(classes_dir))
+    logger.debug("Find unused classes from %s", classes_dir)
     class_paths = set()
     for path in list_all_paths(classes_dir):
         if os.path.isfile(path) and (path.endswith(".yml") or path.endswith(".yaml")):
@@ -152,8 +152,8 @@ def lint_unused_classes(inventory_path):
             path = path.replace(".yml", "").replace(".yaml", "").replace("/", ".")
             class_paths.add(path)
 
-    logger.debug("Collected # of paths: {}".format(len(class_paths)))
-    logger.debug("Checking if all classes are declared in " + classes_dir)
+    logger.debug("Collected # of paths: %s", len(class_paths))
+    logger.debug("Checking if all classes are declared in %s", classes_dir)
 
     for path in list_all_paths(inventory_path):
         if os.path.isfile(path):
@@ -178,9 +178,7 @@ def lint_unused_classes(inventory_path):
     checks_sum = len(class_paths)
     if checks_sum > 0:
         logger.info(
-            "No usage found for the following {} classes:\n{}\n".format(
-                len(class_paths), pformat(class_paths)
-            )
+            "No usage found for the following %s classes:\n%s\n", len(class_paths), pformat(class_paths)
         )
 
     return checks_sum
@@ -193,7 +191,7 @@ def lint_yamllint(inventory_path):
     Yields:
         checks_sum (int): the number of yaml lint issues found
     """
-    logger.debug("Running yamllint for " + inventory_path)
+    logger.debug("Running yamllint for %s", inventory_path)
 
     if os.path.isfile(".yamllint"):
         logger.info("Loading values from .yamllint found.")
@@ -216,11 +214,11 @@ def lint_yamllint(inventory_path):
 
                 if len(problems) > 0:
                     checks_sum += len(problems)
-                    logger.info("File {} has the following issues:".format(path))
+                    logger.info("File %s has the following issues:", path)
                     for problem in problems:
-                        logger.info("\t{}".format(problem))
+                        logger.info("\t%s", problem)
 
     if checks_sum > 0:
-        logger.info("\nTotal yamllint issues found: {}".format(checks_sum))
+        logger.info("\nTotal yamllint issues found: %s", checks_sum)
 
     return checks_sum

--- a/kapitan/refs/base.py
+++ b/kapitan/refs/base.py
@@ -251,8 +251,9 @@ class Revealer(object):
                     )
                 try:
                     logger.debug(
-                        'Revealer: embedded sub-variable path "{}"'
-                        "matched in tag {}".format(ref.embedded_subvar_path, tag)
+                        'Revealer: embedded sub-variable path "%s"' "matched in tag %s",
+                        ref.embedded_subvar_path,
+                        tag,
                     )
                     return self._get_value_in_yaml_path(revealed_yaml, ref.embedded_subvar_path)
                 except KeyError:
@@ -262,7 +263,7 @@ class Revealer(object):
 
             # else this is just a ref
             else:
-                logger.debug('Revealer: no sub-variable path was matched in "{}"'.format(tag))
+                logger.debug('Revealer: no sub-variable path was matched in "%s"', tag)
                 return self._reveal_tag_without_subvar(tag)
 
         # this is a ref with subvar
@@ -270,7 +271,7 @@ class Revealer(object):
             subvar_path = m.groups()
             # strip away the @
             subvar_path = subvar_path[0][1:]
-            logger.debug('Revealer: sub-variable path "{}" matched in tag {}'.format(subvar_path, tag))
+            logger.debug('Revealer: sub-variable path "%s" matched in tag %s', subvar_path, tag)
             tag_without_yaml_path = re.sub(REF_TOKEN_SUBVAR_PATTERN, "", tag)
 
             plaintext = self._reveal_tag_without_subvar(tag_without_yaml_path)
@@ -288,7 +289,7 @@ class Revealer(object):
     @lru_cache(maxsize=256)
     def _reveal_tag_without_subvar(self, tag_without_subvar):
         ref = self.ref_controller[tag_without_subvar]
-        logger.debug("Revealer: revealing tag {} for the first time".format(tag_without_subvar))
+        logger.debug("Revealer: revealing tag %s for the first time", tag_without_subvar)
         return ref.reveal()
 
     def _get_value_in_yaml_path(self, d, yaml_path):

--- a/kapitan/refs/secrets/gpg.py
+++ b/kapitan/refs/secrets/gpg.py
@@ -201,7 +201,9 @@ def fingerprint_non_expired(recipient_name):
                 return key["fingerprint"]
             else:
                 logger.debug(
-                    f"Key for recipient: {recipient_name} with fingerprint: {key['fingerprint']} has expired, skipping"
+                    "Key for recipient: %s with fingerprint: %s has expired, skipping",
+                    recipient_name,
+                    key["fingerprint"],
                 )
         raise GPGError(f"Could not find valid key for recipient: {recipient_name}")
     except IndexError as iexp:

--- a/kapitan/remoteinventory/fetch.py
+++ b/kapitan/remoteinventory/fetch.py
@@ -49,12 +49,12 @@ def fetch_inventories(inventory_path, target_objs, save_dir, force, pool):
                 # output_path is relative to inventory_path
                 # ./inventory by default
                 output_path = normalise_join_path(inventory_path, inv["output_path"])
-                logger.debug("Updated output_path from {} to {}".format(inv["output_path"], output_path))
+                logger.debug("Updated output_path from %s to %s", inv["output_path"], output_path)
                 inv["output_path"] = output_path
 
                 if output_path in inv_output_path[source_uri]:
                     # if the output_path is duplicated for the same source_uri
-                    logger.warning("Skipping duplicate output path for uri {}".format(source_uri))
+                    logger.warning("Skipping duplicate output path for uri %s", source_uri)
                     continue
                 else:
                     inv_output_path[source_uri].add(output_path)
@@ -64,9 +64,9 @@ def fetch_inventories(inventory_path, target_objs, save_dir, force, pool):
                 elif inv_type in ("http", "https"):
                     http_inventories[source_uri].append(inv)
                 else:
-                    logger.warning("{} is not a valid source type".format(inv_type))
+                    logger.warning("%s is not a valid source type", inv_type)
         except KeyError:
-            logger.debug("Target object {} has no inventory key".format(target_obj["vars"]["target"]))
+            logger.debug("Target object %s has no inventory key", target_obj["vars"]["target"])
             continue
 
     git_worker = partial(fetch_git_dependency, save_dir=save_dir, force=force, item_type="Inventory")
@@ -95,9 +95,8 @@ def list_sources(target_objs):
                 sources.append(source_hash.hexdigest()[:8])
         except KeyError:
             logger.debug(
-                "Listing sources: target object {} has no 'inventory' key, continuing".format(
-                    target_obj["vars"]["target"]
-                )
+                "Listing sources: target object %s has no 'inventory' key, continuing",
+                target_obj["vars"]["target"],
             )
             continue
     return sources

--- a/kapitan/resources.py
+++ b/kapitan/resources.py
@@ -221,7 +221,7 @@ def search_imports(cwd, import_str, search_paths):
         # if found, set as full_import_path
         if os.path.exists(_full_import_path):
             full_import_path = _full_import_path
-            logger.debug(f"import_str: {import_str} found in search_path: {install_path}")
+            logger.debug("import_str: %s found in search_path: %s", import_str, install_path)
         else:
             # if import_str not found, search in search_paths
             for path in search_paths:
@@ -229,7 +229,7 @@ def search_imports(cwd, import_str, search_paths):
                 # if found, set as full_import_path
                 if os.path.exists(_full_import_path):
                     full_import_path = _full_import_path
-                    logger.debug(f"import_str: {import_str} found in search_path: {path}")
+                    logger.debug(f"import_str: %s found in search_path: %s", import_str, path)
                     break
 
     # if the above search did not find anything, let jsonnet error
@@ -335,7 +335,7 @@ def inventory_reclass(inventory_path, ignore_class_notfound=False):
                     uri_path = os.path.join(inventory_path, uri_val)
                     normalised_path = os.path.normpath(uri_path)
                     reclass_config.update({uri: normalised_path})
-                logger.debug(f"Using reclass inventory config at: {cfg_file}")
+                logger.debug("Using reclass inventory config at: %s", cfg_file)
         except IOError as ex:
             # If file does not exist, ignore
             if ex.errno == errno.ENOENT:

--- a/kapitan/resources.py
+++ b/kapitan/resources.py
@@ -229,7 +229,7 @@ def search_imports(cwd, import_str, search_paths):
                 # if found, set as full_import_path
                 if os.path.exists(_full_import_path):
                     full_import_path = _full_import_path
-                    logger.debug(f"import_str: %s found in search_path: %s", import_str, path)
+                    logger.debug("import_str: %s found in search_path: %s", import_str, path)
                     break
 
     # if the above search did not find anything, let jsonnet error

--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -688,7 +688,7 @@ def validate_matching_target_name(target_filename, target_obj, inventory_path):
     """Throws *InventoryError* if parameters.kapitan.vars.target is not set,
     or target does not have a corresponding yaml file in *inventory_path*
     """
-    logger.debug(f"validating target name matches the name of yml file {target_filename}")
+    logger.debug("validating target name matches the name of yml file %s", target_filename)
     try:
         target_name = target_obj["vars"]["target"]
     except KeyError:
@@ -713,12 +713,12 @@ def schema_validate_compiled(args):
     validates compiled output according to schemas specified in the inventory
     """
     if not os.path.isdir(args.compiled_path):
-        logger.error(f"compiled-path {args.compiled_path} not found")
+        logger.error("compiled-path %s not found", args.compiled_path)
         sys.exit(1)
 
     if not os.path.isdir(args.schemas_path):
         os.makedirs(args.schemas_path)
-        logger.info(f"created schema-cache-path at {args.schemas_path}")
+        logger.info("created schema-cache-path at %s", args.schemas_path)
 
     worker = partial(schema_validate_kubernetes_output, cache_dir=args.schemas_path)
     pool = multiprocessing.Pool(args.parallelism)
@@ -760,9 +760,7 @@ def create_validate_mapping(target_objs, compiled_path):
     for target_obj in target_objs:
         target_name = target_obj["vars"]["target"]
         if "validate" not in target_obj:
-            logger.debug(
-                "target '{}' does not have 'validate' parameter in inventory. skipping".format(target_name)
-            )
+            logger.debug("target '%s' does not have 'validate' parameter in inventory. skipping", target_name)
             continue
 
         for validate_item in target_obj["validate"]:
@@ -775,11 +773,13 @@ def create_validate_mapping(target_objs, compiled_path):
                 for output_path in validate_item["output_paths"]:
                     full_output_path = os.path.join(compiled_path, target_name, output_path)
                     if not os.path.isfile(full_output_path):
-                        logger.warning(f"{output_path} does not exist for target '{target_name}'. skipping")
+                        logger.warning(
+                            "%s does not exist for target '%s'. skipping", output_path, target_name
+                        )
                         continue
                     validate_files_map[kind_version_pair].append(full_output_path)
             else:
-                logger.warning(f"type {validate_type} is not supported for validation. skipping")
+                logger.warning("type %s is not supported for validation. skipping", validate_type)
 
     return validate_files_map
 

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 try:
     import _jsonnet as jsonnet
 except ImportError as e:
-    logger.debug(f"Could not import jsonnet: {e}")
+    logger.debug("Could not import jsonnet: %s", e)
 
 
 try:
@@ -64,7 +64,7 @@ def hashable_lru_cache(func):
         try:
             return json.loads(value)
         except Exception:
-            logger.debug(f"hashable_lru_cache: {value} not serialiseable, using generic lru_cache instead")
+            logger.debug("hashable_lru_cache: %s not serialiseable, using generic lru_cache instead", value)
             return value
 
     def func_with_serialized_params(*args, **kwargs):
@@ -504,10 +504,10 @@ def unpack_downloaded_file(file_path, output_path, content_type):
             is_unpacked = True
         else:
             extension = re.findall(r"\..*$", file_path)[0]
-            logger.debug(f"File extension {extension} not suported")
+            logger.debug("File extension %s not suported", extension)
             is_unpacked = False
     else:
-        logger.debug(f"Content type {content_type} not suported")
+        logger.debug("Content type %s not suported", content_type)
         is_unpacked = False
     return is_unpacked
 
@@ -533,10 +533,10 @@ def safe_copy_file(src, dst):
         dir = os.path.dirname(dst)
 
     if os.path.isfile(dst):
-        logger.warning("Not updating {} (file already exists)".format(dst))
+        logger.warning("Not updating %s (file already exists)", dst)
         return (dst, 0)
     _copy_file_contents(src, dst)
-    logger.debug("Copied {} to {}".format(src, dir))
+    logger.debug("Copied %s to %s", src, dir)
     return (dst, 1)
 
 
@@ -565,7 +565,7 @@ def safe_copy_tree(src, dst):
         dst_name = os.path.join(dst, name)
 
         if name.startswith("."):
-            logger.debug("Not copying {}".format(src_name))
+            logger.debug("Not copying %s", src_name)
             continue
         if os.path.isdir(src_name):
             outputs.extend(safe_copy_tree(src_name, dst_name))

--- a/kapitan/validator/kubernetes_validator.py
+++ b/kapitan/validator/kubernetes_validator.py
@@ -33,7 +33,7 @@ class KubernetesManifestValidator(Validator):
         validator = jsonschema.Draft4Validator(schema)
         for validate_path in validate_paths:
             if not os.path.isfile(validate_path):
-                logger.warning("{} does not exist. skipping".format(validate_path))
+                logger.warning("%s does not exist. skipping", validate_path)
                 continue
             with open(validate_path, "r") as fp:
                 validate_instance = yaml.safe_load(fp.read())
@@ -45,7 +45,7 @@ class KubernetesManifestValidator(Validator):
                     )
                     raise KubernetesManifestValidationError(error_message)
                 else:
-                    logger.info("Validation: manifest validation successful for {}".format(validate_path))
+                    logger.info("Validation: manifest validation successful for %s", validate_path)
 
     @lru_cache(maxsize=256)
     def _get_schema(self, kind, version):
@@ -72,7 +72,7 @@ class KubernetesManifestValidator(Validator):
 
     def _get_schema_from_web(self, kind, version):
         url = self._get_request_url(kind, version)
-        logger.debug("Validation: fetching schema from {}".format(url))
+        logger.debug("Validation: fetching schema from %s", url)
         try:
             content, _ = make_request(url)
         except requests.exceptions.HTTPError:
@@ -80,7 +80,7 @@ class KubernetesManifestValidator(Validator):
                 "Validation: schema failed to fetch from {}"
                 "\nThe specified version '{}' or kind '{}' may not be supported".format(url, version, kind)
             )
-        logger.debug("Validation: schema fetched  from {}".format(url))
+        logger.debug("Validation: schema fetched  from %s", url)
         return yaml.safe_load(content)
 
     def _get_request_url(self, kind, version):


### PR DESCRIPTION
Using `format()` for logger is discouraged as it forces the message to format the message even when log are disabled.

Moreover, the `.format` vs `%s` is used inconsistently all over the codebase.
Switching all usages to the logger builtin formatting make the code more consistent.

## Proposed Changes

  - convert all usage of `format()` to format logging message to use the builtin logging formatter instead.

