### PR TITLE
Allow helm binding to be compiled with go 1.16

### DIFF
--- a/kapitan/dependency_manager/helm/go.mod
+++ b/kapitan/dependency_manager/helm/go.mod
@@ -1,4 +1,4 @@
-module .
+module dmhelm
 
 go 1.14
 

--- a/kapitan/inputs/helm/go.mod
+++ b/kapitan/inputs/helm/go.mod
@@ -1,4 +1,4 @@
-module .
+module inhelm
 
 go 1.14
 


### PR DESCRIPTION
Signed-off-by: Benjamin Hesmans <benjamin.hesmans@tessares.net>

Fixes issue # ??

Did not find any open issue. I tried the build scripts for the binding with go 1.16 and it was not happy

something like

```
/opt/venv/lib/python3.8/site-packages/kapitan/dependency_manager/helm
go: invalid module path ".": is a local import path
```

## Proposed Changes

  - add a module name to make it build with go 1.16
