### PR TITLE
Fix usage of undefined variable.

### DIFF
--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -15,6 +15,7 @@ import logging
 import multiprocessing
 import os
 import sys
+from functools import partial
 
 import yaml
 from kapitan import cached, defaults, setup_logging
@@ -291,7 +292,7 @@ def main():
     )
 
     inventory_parser = subparser.add_parser("inventory", aliases=["i"], help="show inventory")
-    inventory_parser.set_defaults(func=generate_inventory)
+    inventory_parser.set_defaults(func=partial(generate_inventory, inventory_parser))
 
     inventory_parser.add_argument(
         "--target-name",

--- a/kapitan/resources.py
+++ b/kapitan/resources.py
@@ -282,7 +282,7 @@ def inventory(search_paths, target, inventory_path=None):
     return inventory_reclass(full_inv_path)["nodes"][target]
 
 
-def generate_inventory(args):
+def generate_inventory(parser, args):
     if args.pattern and args.target_name == "":
         parser.error("--pattern requires --target_name")
     try:


### PR DESCRIPTION
parser is not defined in generate_inventory

so call to `parser.error("--pattern requires --target_name")` fails.

