### PR TITLE
Relax kadet output type requirement.

### DIFF
--- a/examples/kubernetes/components/nginx-kadet/__init__.py
+++ b/examples/kubernetes/components/nginx-kadet/__init__.py
@@ -17,9 +17,7 @@ svc_port.root.targetPort = 80
 
 
 def main():
-    output = kadet.BaseObj()
-    output.root.nginx_deployment = kubelib.Deployment(name=name, labels=labels, containers=[nginx_container])
-    output.root.nginx_service = kubelib.Service(
-        name=name, labels=labels, ports=[svc_port], selector=svc_selector
-    )
-    return output
+    return {
+        "nginx_deployment": kubelib.Deployment(name=name, labels=labels, containers=[nginx_container]),
+        "nginx_service": kubelib.Service(name=name, labels=labels, ports=[svc_port], selector=svc_selector),
+    }


### PR DESCRIPTION
## Proposed Changes

There is 2 issues with requiring `BaseObj` in kadet.

### `BaseObj` as return type for main()
 kadet Input expects just a mapping of filename -> `dict`. Requiring a `BaseObj` is confusing as it implies kadet expects a single object and not a list of files. This change adds support for raw `dict` as return type. It simplifies implementation of kadet modules as it remove the need to build a `BaseObj` just to returns a mapping of filenames to `BaseObj`.

For instance, the nginx example may be rewrite as:
```python 
def main():
    return {
      "nginx_deployment": kubelib.Deployment(name=name, labels=labels, containers=[nginx_container]),
      "nginx_service": kubelib.Service(name=name, labels=labels, ports=[svc_port], selector=svc_selector)
    }
```

instead of 
```python 
def main():
    output = kadet.BaseObj()
    output.root.nginx_deployment = kubelib.Deployment(name=name, labels=labels, containers=[nginx_container])
    output.root.nginx_service = kubelib.Service(name=name, labels=labels, ports=[svc_port], selector=svc_selector)
    return output
```

### `BaseObj` as a required type for generated objects.
While using `BaseObj` may be convenient to build a complex nested `dict`, this is not the single way to generate such structure, and imposing it prevents exploring other frameworks. This change also relax this restriction and support simple `dict` in addition of `BaseObj` so any generator/kadet module would be able to generates `dict` as they see fit.

