### PR TITLE
Dockerizes mkdocs setup.

### DIFF
--- a/Dockerfile.docs
+++ b/Dockerfile.docs
@@ -1,0 +1,5 @@
+FROM squidfunk/mkdocs-material:7.1.9
+
+RUN apk update && \
+    pip install pymdown-extensions==8.2 \
+    markdown-include==0.6.0

--- a/Makefile
+++ b/Makefile
@@ -57,3 +57,14 @@ format_codestyle:
 .PHONY: build_helm_fetch_binding
 build_helm_fetch_binding:
 	bash kapitan/dependency_manager/helm/build.sh
+
+.PHONY: local_serve_documentation
+local_serve_documentation:
+	docker build -f Dockerfile.docs --no-cache -t kapitan-docs .
+	docker run --rm -v $(PWD):/docs -p 8000:8000 kapitan-docs
+
+.PHONY: mkdocs_gh_deploy
+mkdocs_gh_deploy:
+	@[ "${COMMIT_MSG}" ] || ( echo ">> COMMIT_MSG is not set"; exit 1 )
+	docker build -f Dockerfile.docs --no-cache -t kapitan-docs .
+	docker run --rm -v $(PWD):/docs -e COMMIT_MSG=$(COMMIT_MSG) kapitan-docs gh-deploy -m "${COMMIT_MSG}" -f ./mkdocs.yml -b gh-pages

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -73,13 +73,7 @@ Updating our gh-pages is therefore a two-step process.
 
 Submit a PR for our master branch that updates the `.md` file(s). Test how the changes would look like when deployed to gh-pages by serving it on localhost:
 
-```
-# from project root
-pip install mkdocs mkdocs-material pymdown-extensions markdown-include
-mkdocs build
-mkdocs serve
-# open http://127.0.0.1:8000
-```
+`make local_serve_documentation`
 
 ### 2. Submit a PR for gh-pages branch to deploy the update
 
@@ -87,7 +81,7 @@ Once the above PR has been merged, use `mkdocs gh-deploy` command to push the co
 
 ```
 # locally, on master branch (which has your updated docs)
-mkdocs gh-deploy -m "Commit message" -f ./mkdocs.yml -b gh-pages
+COMMIT_MSG="your commit message to replace" make mkdocs_gh_deploy
 ```
 
 After it's pushed, create a PR that targets our gh-pages branch from your gh-pages branch.


### PR DESCRIPTION
Not sure if the process for making documentation changes is still valid, but I dockerized the mkdocs setup since I thought it would be easier to view changes locally before submitting a PR.

## Proposed Changes

  - Dockerize mkdocs local preview setup.
  - Dockerize documentation publishing.
 
