### PR TITLE
Update gh pages as a ci job

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,36 @@
+name: Build and deploy documentation on merge to master
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout kapitan recursively
+        uses: actions/checkout@master
+        with:
+          submodules: 'recursive'
+      - name: Strip git ref prefix from tag version and store in TAG_VERSION
+        run: |
+          echo "TAG_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
+          echo "REF_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
+          
+      - name: Strip full version and just keep major part in MAJOR_VERSION VAR
+        run: |
+          echo "MAJOR_VERSION=${TAG_VERSION:0:4}" >> $GITHUB_ENV
+          
+      # Printing versions needs to be a separate step,
+      # as they aren't set during the previous two steps
+      - name: Print Versions
+        run: |
+          echo ${{ env.TAG_VERSION }}
+          echo ${{ env.MAJOR_VERSION }}
+          echo ${{ env.REF_NAME }}
+      
+      - name: Deploy docs
+        uses: mhausenblas/mkdocs-deploy-gh-pages@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CONFIG_FILE: ./mkdocs.yml
+          REQUIREMENTS: "requirements.docs.txt"

--- a/Dockerfile.docs
+++ b/Dockerfile.docs
@@ -1,0 +1,5 @@
+FROM squidfunk/mkdocs-material:7.1.9
+
+RUN apk update && \
+    pip install pymdown-extensions==8.2 \
+    markdown-include==0.6.0

--- a/Dockerfile.docs
+++ b/Dockerfile.docs
@@ -1,5 +1,6 @@
 FROM squidfunk/mkdocs-material:7.1.9
 
+COPY requirements.docs.txt /tmp/requirements.docs.txt
+
 RUN apk update && \
-    pip install pymdown-extensions==8.2 \
-    markdown-include==0.6.0
+    pip install -r /tmp/requirements.docs.txt

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,6 @@ local_serve_documentation:
 	docker run --rm -v $(PWD):/docs -p 8000:8000 kapitan-docs
 
 .PHONY: mkdocs_gh_deploy
-mkdocs_gh_deploy:
-	@[ "${COMMIT_MSG}" ] || ( echo ">> COMMIT_MSG is not set"; exit 1 )
+mkdocs_gh_deploy: # to run locally assuming git ssh access
 	docker build -f Dockerfile.docs --no-cache -t kapitan-docs .
-	docker run --rm -v $(PWD):/docs -e COMMIT_MSG=$(COMMIT_MSG) kapitan-docs gh-deploy -m "${COMMIT_MSG}" -f ./mkdocs.yml -b gh-pages
+	docker run --rm -it -v $(PWD):/src -v ~/.ssh:/root/.ssh -w /src kapitan-docs gh-deploy -f ./mkdocs.yml

--- a/Makefile
+++ b/Makefile
@@ -57,3 +57,14 @@ format_codestyle:
 .PHONY: build_helm_fetch_binding
 build_helm_fetch_binding:
 	bash kapitan/dependency_manager/helm/build.sh
+
+.PHONY: local_serve_documentation
+local_serve_documentation:
+	docker build -f Dockerfile.docs --no-cache -t kapitan-docs .
+	docker run --rm -v $(PWD):/docs -p 8000:8000 kapitan-docs
+
+.PHONY: mkdocs_gh_deploy
+mkdocs_gh_deploy:
+	@[ "${COMMIT_MSG}" ] || ( echo ">> COMMIT_MSG is not set"; exit 1 )
+	docker build -f Dockerfile.docs --no-cache -t kapitan-docs .
+	docker run --rm -v $(PWD):/docs -e COMMIT_MSG=$(COMMIT_MSG) kapitan-docs gh-deploy -m "${COMMIT_MSG}" -f ./mkdocs.yml -b gh-pages

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -73,13 +73,7 @@ Updating our gh-pages is therefore a two-step process.
 
 Submit a PR for our master branch that updates the `.md` file(s). Test how the changes would look like when deployed to gh-pages by serving it on localhost:
 
-```
-# from project root
-pip install mkdocs mkdocs-material pymdown-extensions markdown-include
-mkdocs build
-mkdocs serve
-# open http://127.0.0.1:8000
-```
+`make local_serve_documentation`
 
 ### 2. Submit a PR for gh-pages branch to deploy the update
 
@@ -87,7 +81,7 @@ Once the above PR has been merged, use `mkdocs gh-deploy` command to push the co
 
 ```
 # locally, on master branch (which has your updated docs)
-mkdocs gh-deploy -m "Commit message" -f ./mkdocs.yml -b gh-pages
+COMMIT_MSG="your commit message to replace" make mkdocs_gh_deploy
 ```
 
 After it's pushed, create a PR that targets our gh-pages branch from your gh-pages branch.

--- a/requirements.docs.txt
+++ b/requirements.docs.txt
@@ -1,0 +1,2 @@
+pymdown-extensions==8.2
+markdown-include==0.6.0


### PR DESCRIPTION
Idea is to update documentation whenever a merge to master occurs. It seems to be easier to use the existing mkdocs Github Action which can deploy the changes without huge configuration changes. I created a new requirements.txt file for documentation python dependencies enabling local and CI changes to use the same libraries.

## Proposed Changes

  - update merges to master to automatically update documentation
