### PR TITLE
Allow external compile type to use PATH executable as input

### DIFF
--- a/docs/compile.md
+++ b/docs/compile.md
@@ -552,15 +552,15 @@ parameters:
     compile:
       - input_type: external
         input_paths:
-          - /usr/local/bin/ytt # path to ytt on system
-        output_path: .
+          - ytt # path to ytt on system
+        output_path: ingresses/ingresses.yaml
         args:
           - -f
           - ingresses/ # directory with ingresses
           - -f
           - ytt/remove.yaml # custom ytt script
           - ">"
-          - \${compiled_target_dir}/ingresses/ingresses.yaml # final merged result
+          - \${compiled_target_dir} # will be replace to /tmp/tmp<random>.kapitan/compiled/<target>/ingresses/ingresses.yaml
 ```
 
 *Supported output types*: N/A (no need to specify `output_type`)

--- a/kapitan/inputs/base.py
+++ b/kapitan/inputs/base.py
@@ -38,18 +38,23 @@ class InputType(object):
 
         # expand any globbed paths, taking into account provided search paths
         input_paths = []
-        for input_path in comp_obj["input_paths"]:
-            globbed_paths = [glob.glob(os.path.join(path, input_path)) for path in self.search_paths]
-            inputs = list(itertools.chain.from_iterable(globbed_paths))
-            # remove duplicate inputs
-            inputs = set(inputs)
-            ignore_missing = comp_obj.get("ignore_missing", False)
-            if len(inputs) == 0 and not ignore_missing:
-                raise CompileError(
-                    "Compile error: {} for target: {} not found in "
-                    "search_paths: {}".format(input_path, ext_vars["target"], self.search_paths)
-                )
-            input_paths.extend(inputs)
+
+        if input_type == "external":
+            input_paths = comp_obj["input_paths"]
+
+        else:
+            for input_path in comp_obj["input_paths"]:
+                globbed_paths = [glob.glob(os.path.join(path, input_path)) for path in self.search_paths]
+                inputs = list(itertools.chain.from_iterable(globbed_paths))
+                # remove duplicate inputs
+                inputs = set(inputs)
+                ignore_missing = comp_obj.get("ignore_missing", False)
+                if len(inputs) == 0 and not ignore_missing:
+                    raise CompileError(
+                        "Compile error: {} for target: {} not found in "
+                        "search_paths: {}".format(input_path, ext_vars["target"], self.search_paths)
+                    )
+                input_paths.extend(inputs)
 
         for input_path in input_paths:
             self.compile_input_path(input_path, comp_obj, ext_vars, **kwargs)

--- a/kapitan/inputs/external.py
+++ b/kapitan/inputs/external.py
@@ -8,9 +8,6 @@
 import subprocess
 import re
 import logging
-import os
-import shutil
-from distutils.dir_util import copy_tree
 
 from kapitan.inputs.base import InputType
 
@@ -42,19 +39,15 @@ class External(InputType):
 
             args = [external_path]
             args.extend(self.args)
-            args = " ".join(args)
 
             # compile_path (str): Path to current target compiled directory
-            args = re.sub(r"(\${compiled_target_dir})", compile_path, args)
+            args = [re.sub(r"(\${compiled_target_dir})", compile_path, arg) for arg in args]
 
             logger.debug("Executing external input with command '%s' and env vars '%s'.", args, self.env_vars)
-
             external_result = subprocess.run(
                 args,
-                env=self.env_vars,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                shell=True,
                 encoding="utf8",
             )
 


### PR DESCRIPTION
Fix for https://github.com/kapicorp/kapitan/issues/695