### PR TITLE
Print inventory render time

### DIFF
--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -87,6 +87,7 @@ def compile_targets(
     pool = multiprocessing.Pool(parallel)
 
     try:
+        rendering_start = time.time()
         if kwargs.get("fetch_inventories", False):
             # skip classes that are not yet available
             target_objs = load_target_inventory(inventory_path, updated_targets, ignore_class_notfound=True)
@@ -120,6 +121,7 @@ def compile_targets(
             fetch_dependencies(
                 output_path, target_objs, dep_cache_dir, kwargs.get("force_fetch", False), pool
             )
+        logger.info("Rendered inventory (%.2fs)", time.time() - rendering_start)
 
         worker = partial(
             compile_target,


### PR DESCRIPTION
Fixes issue #745

## Proposed Changes

  - Print time to spent rendering inventory like below
  
  ```
Rendered inventory (0.10s)
Compiled removal (0.00s)
Compiled labels (0.10s)
Compiled busybox (0.11s)
...
  ```