### PR TITLE
Add plain ref type description to secrets.md

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -53,7 +53,8 @@ $ kapitan refs --write <secret_type>:path/to/secret/file -t <target_name> -f <se
 
 ​	where `<secret_type>` can be any of:
 
-- `base64`: base64 (not encrypted!)
+- `plain`: plain - directly written on the disk in plain text (good for random string generation on kapitan level). Not suitable for secrets.
+- `base64`: base64 (not encrypted!). Not suitable for secrets.
 - `gpg`: GPG
 - `gkms`: Google Cloud KMS
 - `awskms`: AWS KMS


### PR DESCRIPTION
## Proposed Changes

Add plain ref type to the other types for convenience. This is only mentioned in the Proposal page for refs but has a very useful case.