### PR TITLE
kapitan: fix python tests.

### DIFF
--- a/tests/test_helm_input.py
+++ b/tests/test_helm_input.py
@@ -122,7 +122,7 @@ class HelmInputTest(unittest.TestCase):
         with open(controller_deployment_file, "r") as fp:
             manifest = yaml.safe_load(fp.read())
             name = manifest["metadata"]["name"]
-            self.assertEqual("RELEASE-NAME-nginx-ingress-my-controller", name)
+            self.assertEqual("release-name-nginx-ingress-my-controller", name)
 
     def test_compile_with_helm_values_files(self):
         temp = tempfile.mkdtemp()


### PR DESCRIPTION
This change needs to be merged first: https://github.com/kapicorp/reclass/pull/7

* On the latest version, to render helm template it now uses the helm
  cli directly. However it seems using helm 3.8.0 (the latest stable),
  the default behavior if to release name is specify is to populate with
  the string "release-name", not "RELEASE-NAME" hence all lowercase.
  There's a simple way to reproduce:
  ```
  helm create test-chart
  helm template --include-crds --skip-tests
  ````
  And check how {{ .Release.Name }} gets populated when there's none
  specified.

Signed-off-by: Lionel H <me@nullbyte.be>

Fixes issue #

## Proposed Changes

  -
  -
  -
