### PR TITLE
Open binary files in binary mode and do not encode them

### DIFF
--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -402,6 +402,12 @@ def main():
         default=from_dot_kapitan("refs", "base64", False),
     )
     refs_parser.add_argument(
+        "--binary",
+        help="file content should be handled as binary data",
+        action="store_true",
+        default=from_dot_kapitan("refs", "binary", False),
+    )
+    refs_parser.add_argument(
         "--reveal",
         "-r",
         help="reveal refs",

--- a/kapitan/refs/base64.py
+++ b/kapitan/refs/base64.py
@@ -40,7 +40,11 @@ class Base64Ref(PlainRef):
 
     def reveal(self):
         # TODO data should be bytes only
-        return base64.b64decode(self.data).decode()
+        decoded = base64.b64decode(self.data)
+        try:
+            return decoded.decode()
+        except:
+            return self.data
 
     def compile_embedded(self):
         dump = self.dump()

--- a/kapitan/refs/cmd_parser.py
+++ b/kapitan/refs/cmd_parser.py
@@ -38,8 +38,8 @@ def ref_write(args, ref_controller):
     "Write ref to ref_controller based on cli args"
     token_name = args.write
     file_name = args.file
+    is_binary = args.binary
     data = None
-    is_binary = False
 
     if file_name is None:
         fatal_error("--file is required with --write")
@@ -49,11 +49,12 @@ def ref_write(args, ref_controller):
             data += line
     else:
         mime_type = mimetypes.guess_type(file_name)
-        modifier = "r" if "text" in mime_type or  mime_type[0] is None else "rb"
+        modifier = "rb" if is_binary else "r"
         with open(file_name, modifier) as fp:
-            data = fp.read()
-            if "b" in fp.mode:
-                is_binary = True
+            try:
+                data = fp.read()
+            except UnicodeDecodeError as e:
+                raise KapitanError("Could not read file. Please add '--binary' if the file contains binary data. ({})".format(e))
 
     if token_name.startswith("gpg:"):
         type_name, token_path = token_name.split(":")

--- a/kapitan/refs/cmd_parser.py
+++ b/kapitan/refs/cmd_parser.py
@@ -49,7 +49,7 @@ def ref_write(args, ref_controller):
             data += line
     else:
         mime_type = mimetypes.guess_type(file_name)
-        modifier = "r" if "text" in mime_type else "rb"
+        modifier = "r" if "text" in mime_type or  mime_type[0] is None else "rb"
         with open(file_name, modifier) as fp:
             data = fp.read()
             if "b" in fp.mode:

--- a/kapitan/refs/cmd_parser.py
+++ b/kapitan/refs/cmd_parser.py
@@ -52,7 +52,7 @@ def ref_write(args, ref_controller):
         modifier = "r" if "text" in mime_type else "rb"
         with open(file_name, modifier) as fp:
             data = fp.read()
-            if 'b' in fp.mode:
+            if "b" in fp.mode:
                 is_binary = True
 
     if token_name.startswith("gpg:"):
@@ -185,7 +185,7 @@ def ref_write(args, ref_controller):
 
     elif token_name.startswith("vaultkv:"):
         type_name, token_path = token_name.split(":")
-        _data = data.encode()
+        _data = data if is_binary else data.encode()
         vault_params = {}
         encoding = "original"
         if args.target_name:
@@ -219,7 +219,7 @@ def ref_write(args, ref_controller):
 
     elif token_name.startswith("plain:"):
         type_name, token_path = token_name.split(":")
-        _data = data.encode()
+        _data = data if is_binary else data.encode()
         encoding = "original"
         if args.base64:
             _data = base64.b64encode(_data).decode()
@@ -231,7 +231,7 @@ def ref_write(args, ref_controller):
 
     elif token_name.startswith("env:"):
         type_name, token_path = token_name.split(":")
-        _data = data.encode()
+        _data = data if is_binary else data.encode()
         encoding = "original"
         if args.base64:
             _data = base64.b64encode(_data).decode()


### PR DESCRIPTION
Fixes #791

The MIME type of files is checked for the "text" keyword. If it is present, the file will be opened in standard text mode (modifier `r`), if not it is assumed to be binary data and opened in binary mode (modifier `rb`).
In case of a binary file, the UTF-8 encoding will be skipped.

Related to https://github.com/kapicorp/kapitan-reference/issues/106