### PR TITLE
Accept content-type `application/gzip` when unpacking dependencies

### DIFF
--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -492,6 +492,7 @@ def unpack_downloaded_file(file_path, output_path, content_type):
         zfile.close()
         is_unpacked = True
     elif content_type in [
+        "application/gzip",
         "application/octet-stream",
         "application/x-gzip",
         "application/x-compressed",


### PR DESCRIPTION
## Proposed Changes

The content-type `application/gzip` has been introduced in [RFC 6713][1]  as an official type which was intendend to be used instead of various custom content types, such as `application/x-gzip`.

It appears that adoption of `application/gzip` is not very high, so its absence from the list of content types which Kapitan tries to unpack hasn't caused issues yet.

However, we've now found a dependency (Cilium Enterprise Edition OLM manifests) which is served with `content-type: application/gzip` which results in the following log messages from Kapitan:

```
Dependency https://<REDACTED>/cilium-ee-1.10.4.tar.gz: fetching now
Dependency https://<REDACTED>/cilium-ee-1.10.4.tar.gz: successfully fetched
Dependency https://<REDACTED>/cilium-ee-1.10.4.tar.gz: Content-Type application/gzip is not supported for unpack. Ignoring save
```

This commit adds `application/gzip` as a supported content type for `.tar.gz` archives in `unpack_downloaded_file()`.

[1]: https://datatracker.ietf.org/doc/html/rfc6713