### PR TITLE
feature: add new lower_alpha_num ref function

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -74,6 +74,7 @@ When referencing your secret in the inventory during compile, you can use the fo
 - `ed25519` - Generates a ed25519 private key (PKCS#8).
 - `publickey` - Derives the public key from a revealed private key i.e. `||reveal:path/to/encrypted_private_key|publickey`
 - `rsapublic` - Derives an RSA public key from a revealed private key i.e. `||reveal:path/to/encrypted_private_key|rsapublic` (deprecated, use `publickey` instead)
+- `lower_alpha_num` - Generates a DNS-compliant text string (a-z and 0-9), containing lower alphanum chars sets it to ctx.data `||`
 
 *Note*: The first operator here `||` is more similar to a logical OR. If the secret file doesn't exist, kapitan will generate it and apply the functions after the `||`. If the secret file already exists, no functions will run.
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -74,7 +74,7 @@ When referencing your secret in the inventory during compile, you can use the fo
 - `ed25519` - Generates a ed25519 private key (PKCS#8).
 - `publickey` - Derives the public key from a revealed private key i.e. `||reveal:path/to/encrypted_private_key|publickey`
 - `rsapublic` - Derives an RSA public key from a revealed private key i.e. `||reveal:path/to/encrypted_private_key|rsapublic` (deprecated, use `publickey` instead)
-- `lower_alpha_num` - Generates a DNS-compliant text string (a-z and 0-9), containing lower alphanum chars sets it to ctx.data `||`
+- `loweralphanum` - Generates a DNS-compliant text string (a-z and 0-9), containing lower alphanum chars `||`
 
 *Note*: The first operator here `||` is more similar to a logical OR. If the secret file doesn't exist, kapitan will generate it and apply the functions after the `||`. If the secret file already exists, no functions will run.
 

--- a/kapitan/refs/functions.py
+++ b/kapitan/refs/functions.py
@@ -9,6 +9,7 @@ import base64
 import hashlib
 import logging
 import secrets  # python secrets module
+import string
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
@@ -28,6 +29,7 @@ def eval_func(func_name, ctx, *func_params):
         "rsapublic": rsa_public_key,
         "publickey": public_key,
         "reveal": reveal,
+        "lower_alpha_num": lower_alpha_num,
     }
 
     return func_lookup[func_name](ctx, *func_params)
@@ -140,3 +142,16 @@ def reveal(ctx, secret_path):
         raise RefError(
             f"|reveal function error: {secret_path} file in {ctx.token}|reveal:{secret_path} does not exist"
         )
+
+
+def lower_alpha_num(ctx, chars="8"):
+    """
+    generates a DNS-compliant text string (a-z and 0-9), containing lower alphanum chars
+    sets it to ctx.data
+    """
+    pool = string.ascii_lowercase + string.digits
+    try:
+        chars = int(chars)
+    except ValueError:
+        raise RefError(f"Ref error: eval_func: {chars} cannot be converted into integer.")
+    ctx.data = "".join(secrets.choice(pool) for i in range(chars))

--- a/kapitan/refs/functions.py
+++ b/kapitan/refs/functions.py
@@ -29,7 +29,7 @@ def eval_func(func_name, ctx, *func_params):
         "rsapublic": rsa_public_key,
         "publickey": public_key,
         "reveal": reveal,
-        "lower_alpha_num": lower_alpha_num,
+        "loweralphanum": loweralphanum,
     }
 
     return func_lookup[func_name](ctx, *func_params)
@@ -144,10 +144,9 @@ def reveal(ctx, secret_path):
         )
 
 
-def lower_alpha_num(ctx, chars="8"):
+def loweralphanum(ctx, chars="8"):
     """
     generates a DNS-compliant text string (a-z and 0-9), containing lower alphanum chars
-    sets it to ctx.data
     """
     pool = string.ascii_lowercase + string.digits
     try:

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -420,3 +420,23 @@ class Base64RefsTest(unittest.TestCase):
             raise Exception("ref is not sha256 hash")
 
     # TODO write tests for RefController errors (lookups, etc..)
+
+    def test_ref_function_lower_alpha_num(self):
+        "write lower_alpha_num to secret, confirm ref file exists, reveal and check"
+
+        tag = "?{plain:ref/lower_alpha_num||lower_alpha_num}"
+        REF_CONTROLLER[tag] = RefParams()
+        self.assertTrue(os.path.isfile(os.path.join(REFS_HOME, "ref/lower_alpha_num")))
+
+        file_with_tags = tempfile.mktemp()
+        with open(file_with_tags, "w") as fp:
+            fp.write("?{plain:ref/lower_alpha_num}")
+        revealed = REVEALER.reveal_raw_file(file_with_tags)
+        self.assertEqual(len(revealed), 8)  # default length of lower_alpha_num string is 8
+
+        # Test with parameter chars=16, correlating with string length 16
+        tag = "?{plain:ref/lower_alpha_num||lower_alpha_num:16}"
+        REF_CONTROLLER[tag] = RefParams()
+        REVEALER._reveal_tag_without_subvar.cache_clear()
+        revealed = REVEALER.reveal_raw_file(file_with_tags)
+        self.assertEqual(len(revealed), 16)

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -421,21 +421,21 @@ class Base64RefsTest(unittest.TestCase):
 
     # TODO write tests for RefController errors (lookups, etc..)
 
-    def test_ref_function_lower_alpha_num(self):
-        "write lower_alpha_num to secret, confirm ref file exists, reveal and check"
+    def test_ref_function_loweralphanum(self):
+        "write loweralphanum to secret, confirm ref file exists, reveal and check"
 
-        tag = "?{plain:ref/lower_alpha_num||lower_alpha_num}"
+        tag = "?{plain:ref/loweralphanum||loweralphanum}"
         REF_CONTROLLER[tag] = RefParams()
-        self.assertTrue(os.path.isfile(os.path.join(REFS_HOME, "ref/lower_alpha_num")))
+        self.assertTrue(os.path.isfile(os.path.join(REFS_HOME, "ref/loweralphanum")))
 
         file_with_tags = tempfile.mktemp()
         with open(file_with_tags, "w") as fp:
-            fp.write("?{plain:ref/lower_alpha_num}")
+            fp.write("?{plain:ref/loweralphanum}")
         revealed = REVEALER.reveal_raw_file(file_with_tags)
-        self.assertEqual(len(revealed), 8)  # default length of lower_alpha_num string is 8
+        self.assertEqual(len(revealed), 8)  # default length of loweralphanum string is 8
 
         # Test with parameter chars=16, correlating with string length 16
-        tag = "?{plain:ref/lower_alpha_num||lower_alpha_num:16}"
+        tag = "?{plain:ref/loweralphanum||loweralphanum:16}"
         REF_CONTROLLER[tag] = RefParams()
         REVEALER._reveal_tag_without_subvar.cache_clear()
         revealed = REVEALER.reveal_raw_file(file_with_tags)


### PR DESCRIPTION
## Proposed Changes

  - add lower_alpha_num ref function which generates string without any special characters or capital letters to be compliant with accountName of Azure StorageAccounts - https://docs.microsoft.com/en-us/rest/api/storagerp/storage-accounts/create

