### PR TITLE
Add support for Helm charts from OCI registries

### DIFF
--- a/docs/external_dependencies.md
+++ b/docs/external_dependencies.md
@@ -176,6 +176,8 @@ Fetches helm charts and any specific subcharts in the `requirements.yaml` file.
 It defaults to the value of the `KAPITAN_HELM_PATH` environment var or simply to `helm` if neither is set.
 You should specify only if you don't want the default behavior.
 
+`source` can be either the URL to a chart repository, or the URL to a chart on an OCI registry (supported since Helm 3.8.0).
+
 ### Usage
 
 ```yaml
@@ -184,7 +186,7 @@ parameters:
     dependencies:
     - type: helm
       output_path: path/to/chart
-      source: http[s]://<helm_chart_repository_url>
+      source: http[s]|oci://<helm_chart_repository_url>
       version: <specific chart version>
       chart_name: <name of chart>
       helm_path: <helm binary>

--- a/kapitan/dependency_manager/base.py
+++ b/kapitan/dependency_manager/base.py
@@ -248,13 +248,18 @@ def fetch_helm_archive(helm_path, repo, chart_name, version, save_path):
     logger.info("Dependency helm chart %s and version %s: fetching now", chart_name, version or "latest")
     # Fetch archive and untar it into parent dir
     save_dir = os.path.dirname(save_path)
-    args = ["pull", "--destination", save_dir, "--untar", "--repo", repo]
+    args = ["pull", "--destination", save_dir, "--untar"]
 
     if version:
         args.append("--version")
         args.append(version)
 
-    args.append(chart_name)
+    if repo.startswith("oci://"):
+        args.append(repo)
+    else:
+        args.append("--repo")
+        args.append(repo)
+        args.append(chart_name)
 
     response = helm_cli(helm_path, args)
     if response != "":


### PR DESCRIPTION
Since version 3.8.0 Helm supports OCI registries for chart storage [https://helm.sh/docs/topics/registries](https://helm.sh/docs/topics/registries/), but the `helm pull` command used to fetch a chart from an OCI registry slightly changes, the `--repo` flag have to be omitted because it only works with http(s) chart repositories. Helm expects the fully-qualified URL to the chart instead as argument.

## Proposed Changes

This PR adds support for Helm chart dependencies from OCI registries by removing the `--repo` flag passed to the `helm` command when the `oci://` prefix is detected in the `source` property, and pass it as argument instead.

For instance, this configuration:
```yaml
  kapitan:
    dependencies:
    - type: helm
      output_path: charts/example
      source: oci://europe-west1-docker.pkg.dev/my-project/helm-charts/example
      version: 1.2.3
      chart_name: example
```

 will generate the following Helm command:
```shell
helm pull --destination charts/example --untar --version 1.2.3 oci://europe-west1-docker.pkg.dev/my-project/helm-charts/example
```