### PR TITLE
Fix kadet serialization to yaml not preserving key orders (#835)

### DIFF
--- a/examples/kubernetes/compiled/minikube-nginx-kadet/manifests/nginx_deployment.yml
+++ b/examples/kubernetes/compiled/minikube-nginx-kadet/manifests/nginx_deployment.yml
@@ -11,7 +11,7 @@ spec:
         app: nginx
     spec:
       containers:
-        - image: nginx:1:15.8
-          name: nginx
+        - name: nginx
+          image: nginx:1:15.8
           ports:
             - containerPort: 80

--- a/examples/kubernetes/compiled/minikube-nginx-kadet/manifests/nginx_service.yml
+++ b/examples/kubernetes/compiled/minikube-nginx-kadet/manifests/nginx_service.yml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    app: nginx
   name: nginx
   namespace: minikube-nginx-kadet
+  labels:
+    app: nginx
 spec:
   ports:
     - name: http

--- a/kapitan/inputs/base.py
+++ b/kapitan/inputs/base.py
@@ -123,10 +123,22 @@ class CompilingFile(object):
 
         if obj:
             if isinstance(obj, Mapping):
-                yaml.dump(obj, stream=self.fp, indent=indent, Dumper=PrettyDumper, default_flow_style=False)
+                yaml.dump(
+                    obj,
+                    stream=self.fp,
+                    indent=indent,
+                    Dumper=PrettyDumper,
+                    default_flow_style=False,
+                    sort_keys=False,
+                )
             else:
                 yaml.dump_all(
-                    obj, stream=self.fp, indent=indent, Dumper=PrettyDumper, default_flow_style=False
+                    obj,
+                    stream=self.fp,
+                    indent=indent,
+                    Dumper=PrettyDumper,
+                    default_flow_style=False,
+                    sort_keys=False,
                 )
 
             logger.debug("Wrote %s", self.fp.name)

--- a/tests/test_resources/compiled/kadet-test/test-1/test_deployment.yaml
+++ b/tests/test_resources/compiled/kadet-test/test-1/test_deployment.yaml
@@ -1,21 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  labels:
-    team_name: client-operations
   name: app-name
   namespace: ops
+  labels:
+    team_name: client-operations
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: app-name
+  replicas: 1
   template:
     metadata:
       labels:
         app: app-name
     spec:
       containers:
-        - image: hello-word
+        - name: hello
+          image: hello-word
           imagePullPolicy: Always
-          name: hello

--- a/tests/test_resources/compiled/kadet-test/test-2/test_deployment.yaml
+++ b/tests/test_resources/compiled/kadet-test/test-2/test_deployment.yaml
@@ -1,21 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  labels:
-    team_name: SRE
   name: app-name
   namespace: team-2
+  labels:
+    team_name: SRE
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: app-name
+  replicas: 1
   template:
     metadata:
       labels:
         app: app-name
     spec:
       containers:
-        - image: hello-word
+        - name: hello
+          image: hello-word
           imagePullPolicy: Always
-          name: hello


### PR DESCRIPTION
Fixes issue #835 

## Proposed Changes

  - Makes kadet not sort keys when dumping into YAML, this fixes inconsistencies with JSON and makes the result much easier to read if it was loaded with `.update_root` before