### PR TITLE
Conditional dependency download and compile

### DIFF
--- a/kapitan/dependency_manager/base.py
+++ b/kapitan/dependency_manager/base.py
@@ -48,6 +48,12 @@ def fetch_dependencies(output_path, target_objs, save_dir, force, pool):
         try:
             dependencies = target_obj["dependencies"]
             for item in dependencies:
+                if not item.get("condition", True):
+                    logger.warning(
+                        "Skipping dependency download for uri %s because condition is false", item["source"]
+                    )
+                    continue
+
                 dependency_type = item["type"]
                 source_uri = item["source"]
 

--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -472,6 +472,12 @@ def compile_target(target_obj, search_paths, compile_path, ref_controller, globa
         input_type = comp_obj["input_type"]
         output_path = comp_obj["output_path"]
 
+        if not comp_obj.get("condition", True):
+            logger.warning(
+                "Skipping compile for type %s and output_path %s because condition is false", input_type, output_path
+            )
+            continue
+
         if input_type == "jinja2":
             input_compiler = Jinja2(compile_path, search_paths, ref_controller)
             if "input_params" in comp_obj:
@@ -586,6 +592,7 @@ def valid_target_obj(target_obj, require_compile=True):
                 "items": {
                     "type": "object",
                     "properties": {
+                        "conditon": {"type": "boolean"},
                         "name": {"type": "string"},
                         "input_paths": {"type": "array"},
                         "input_type": {"type": "string"},
@@ -649,6 +656,7 @@ def valid_target_obj(target_obj, require_compile=True):
                 "items": {
                     "type": "object",
                     "properties": {
+                        "condition": {"type": "boolean"},
                         "chart_name": {"type": "string"},
                         "type": {"type": "string", "enum": ["git", "http", "https", "helm"]},
                         "output_path": {"type": "string"},
@@ -666,6 +674,7 @@ def valid_target_obj(target_obj, require_compile=True):
                             "if": {"properties": {"type": {"enum": ["http", "https"]}}},
                             "then": {
                                 "properties": {
+                                    "condition": {},
                                     "type": {},
                                     "source": {"format": "uri"},
                                     "output_path": {},
@@ -679,6 +688,7 @@ def valid_target_obj(target_obj, require_compile=True):
                             "if": {"properties": {"type": {"enum": ["helm"]}}},
                             "then": {
                                 "properties": {
+                                    "condition": {},
                                     "type": {},
                                     "source": {"format": "uri"},
                                     "output_path": {},


### PR DESCRIPTION
## Proposed Changes

Depending on features turned on or off, this allows to individual
download or skip certain dependencies and compile them just if they
turned on.

The default behavior of download and compile everything doesn't
change with it. Existing use cases must not have any behavior changes.