### PR TITLE
Feature: Added force-fetch functionality (#858)

### DIFF
--- a/docs/external_dependencies.md
+++ b/docs/external_dependencies.md
@@ -32,10 +32,10 @@ $ kapitan compile --fetch
 This will download the dependencies and store them at their respective `output_path`.
 By default, kapitan does not overwrite existing items with the same name as that of the fetched dependencies.
 
-Use the `--force` flag to force fetch (update cache with freshly fetched dependencies) and overwrite any existing item sharing the same name in the `output_path`.
+Use the `--force-fetch` flag to force fetch (update cache with freshly fetched dependencies) and overwrite any existing item sharing the same name in the `output_path`.
 
 ```
-$ kapitan compile --fetch --force
+$ kapitan compile --force-fetch
 ```
 
 Use the `--cache` flag to cache the fetched items in the `.dependency_cache` directory in the root project directory.

--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -277,10 +277,10 @@ $ kapitan compile --fetch
 This will download the dependencies and store them at their respective `output_path`.
 By default, kapitan does not overwrite an existing item with the same name as that of the fetched inventory items.
 
-Use the `--force` flag to force fetch (update cache with freshly fetched items) and overwrite inventory items of the same name in the `output_path`.
+Use the `--force-fetch` flag to force fetch (update cache with freshly fetched items) and overwrite inventory items of the same name in the `output_path`.
 
 ```
-$ kapitan compile --fetch --force
+$ kapitan compile --fetch --force-fetch
 ```
 
 Use the `--cache` flag to cache the fetched items in the `.dependency_cache` directory in the root project directory.

--- a/docs/kap_proposals/kap_1_external_dependencies.md
+++ b/docs/kap_proposals/kap_1_external_dependencies.md
@@ -27,6 +27,7 @@ Git type may also include `ref` and `subdir` parameters as illustrated below:
   source: <git_url>
   subdir: relative/path/in/repository
   ref: <commit_hash/branch/tag>
+  fetch_always: <bool>
 ```
 
 If the file already exists at `output_path`, the fetch will be skipped. For fresh fetch of the dependencies, users may add `--fetch` option as follows:
@@ -35,7 +36,7 @@ If the file already exists at `output_path`, the fetch will be skipped. For fres
 $ kapitan compile --fetch
 ```
 
-Users can also add the `fetch_always: true` option to the `kapitan.compile` in the inventory in order to force fresh fetch of the dependencies every time.
+Users can also add the `fetch_always: true` option to the `kapitan.dependencies` in the inventory in order to force fetch of the dependencies of the target every time.
 
 ## Implementation details
 

--- a/docs/kap_proposals/kap_1_external_dependencies.md
+++ b/docs/kap_proposals/kap_1_external_dependencies.md
@@ -27,7 +27,7 @@ Git type may also include `ref` and `subdir` parameters as illustrated below:
   source: <git_url>
   subdir: relative/path/in/repository
   ref: <commit_hash/branch/tag>
-  fetch_always: <bool>
+  force_fetch: <bool>
 ```
 
 If the file already exists at `output_path`, the fetch will be skipped. For fresh fetch of the dependencies, users may add `--fetch` option as follows:

--- a/docs/kap_proposals/kap_1_external_dependencies.md
+++ b/docs/kap_proposals/kap_1_external_dependencies.md
@@ -36,7 +36,7 @@ If the file already exists at `output_path`, the fetch will be skipped. For fres
 $ kapitan compile --fetch
 ```
 
-Users can also add the `fetch_always: true` option to the `kapitan.dependencies` in the inventory in order to force fetch of the dependencies of the target every time.
+Users can also add the `force_fetch: true` option to the `kapitan.dependencies` in the inventory in order to force fetch of the dependencies of the target every time.
 
 ## Implementation details
 

--- a/docs/kap_proposals/kap_7_remote_inventory.md
+++ b/docs/kap_proposals/kap_7_remote_inventory.md
@@ -31,9 +31,9 @@ eg. `$ kapitan compile --fetch --cache`
 ## Force fetching
 While fetching, the output path will be recursively checked to see if it contains any file with the same name. If so, kapitan will skip fetching it.
 
-To overwrite the files with the newly downloaded inventory items, we can add the `--force` flag to the compile command, as shown below.
+To overwrite the files with the newly downloaded inventory items, we can add the `--force-fetch` flag to the compile command, as shown below.
 
-`$ kapitan compile --fetch --force`
+`$ kapitan compile --force-fetch`
 
 ## URL type
 The URL type can be either git or http(s). Depending on the URL type, the configuration file may have additional arguments.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -57,7 +57,7 @@ optional arguments:
   --quiet               set quiet mode, only critical output
   --output-path PATH    set output path, default is "."
   --fetch               fetch remote inventories and/or external dependencies
-  --force               overwrite existing inventory and/or dependency item
+  --force-fetch         overwrite existing inventory and/or dependency item
   --validate            validate compile output against schemas as specified
                         in inventory
   --parallelism INT, -p INT

--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -87,7 +87,7 @@ def trigger_compile(args):
         cache_paths=args.cache_paths,
         fetch=args.fetch,
         force_fetch=args.force_fetch,
-        force=args.force, # deprecated
+        force=args.force,  # deprecated
         validate=args.validate,
         schemas_path=args.schemas_path,
         jinja2_filters=args.jinja2_filters,

--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -85,9 +85,9 @@ def trigger_compile(args):
         reveal=args.reveal,
         cache=args.cache,
         cache_paths=args.cache_paths,
-        fetch_inventories=args.fetch,
-        fetch_dependencies=args.fetch,
-        force_fetch=args.force,
+        fetch=args.fetch,
+        force_fetch=args.force_fetch,
+        force=args.force, # deprecated
         validate=args.validate,
         schemas_path=args.schemas_path,
         jinja2_filters=args.jinja2_filters,
@@ -184,6 +184,12 @@ def build_parser():
         default=from_dot_kapitan("compile", "fetch", False),
     )
     compile_parser.add_argument(
+        "--force-fetch",
+        help="overwrite existing inventory and/or dependency item",
+        action="store_true",
+        default=from_dot_kapitan("compile", "force-fetch", False),
+    )
+    compile_parser.add_argument(  # deprecated
         "--force",
         help="overwrite existing inventory and/or dependency item",
         action="store_true",

--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -129,23 +129,23 @@ def compile_targets(
         # fetch dependencies
         if fetch:
             fetch_dependencies(output_path, target_objs, dep_cache_dir, force_fetch, pool)
-        # fetch targets which have fetch_always: true
+        # fetch targets which have force_fetch: true
         elif not kwargs.get("force_fetch", False):
             fetch_objs = []
             # iterate through targets
             for target in target_objs:
                 try:
-                    # get value of "fetch_always" property
+                    # get value of "force_fetch" property
                     dependencies = target["dependencies"]
                     # dependencies is still a list
                     for entry in dependencies:
-                        fetch_always = entry["fetch_always"]
-                        if fetch_always:
+                        force_fetch = entry["force_fetch"]
+                        if force_fetch:
                             fetch_objs.append(target)
                 except KeyError:
-                    # targets may have no "dependencies" or "fetch_always" key
+                    # targets may have no "dependencies" or "force_fetch" key
                     continue
-            # fetch dependencies from targets with fetch_always set to true
+            # fetch dependencies from targets with force_fetch set to true
             if fetch_objs:
                 fetch_dependencies(output_path, fetch_objs, dep_cache_dir, True, pool)
 
@@ -652,7 +652,7 @@ def valid_target_obj(target_obj, require_compile=True):
                         "ref": {"type": "string"},
                         "unpack": {"type": "boolean"},
                         "version": {"type": "string"},
-                        "fetch_always": {"type": "boolean"},
+                        "force_fetch": {"type": "boolean"},
                     },
                     "required": ["type", "output_path", "source"],
                     "additionalProperties": False,
@@ -665,7 +665,7 @@ def valid_target_obj(target_obj, require_compile=True):
                                     "source": {"format": "uri"},
                                     "output_path": {},
                                     "unpack": {},
-                                    "fetch_always": {},
+                                    "force_fetch": {},
                                 },
                                 "additionalProperties": False,
                             },
@@ -680,7 +680,7 @@ def valid_target_obj(target_obj, require_compile=True):
                                     "unpack": {},
                                     "chart_name": {"type": "string"},
                                     "version": {"type": "string"},
-                                    "fetch_always": {},
+                                    "force_fetch": {},
                                 },
                                 "required": ["type", "output_path", "source", "chart_name"],
                                 "additionalProperties": False,

--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -117,6 +117,26 @@ def compile_targets(
             fetch_dependencies(
                 output_path, target_objs, dep_cache_dir, kwargs.get("force_fetch", False), pool
             )
+        # if --force is set, ignore dependencies property
+        elif not kwargs.get("force_fetch", False):
+            fetch_objs = []
+            # iterate through targets
+            for target in target_objs:
+                try:
+                    # get value of "fetch_always" property
+                    dependencies = target["dependencies"]
+                    # dependencies is still a list
+                    for entry in dependencies:
+                        fetch_always = entry["fetch_always"]
+                        if fetch_always:
+                            fetch_objs.append(target)
+                except KeyError:
+                    # targets may have no "dependencies" or "fetch_always" key
+                    continue
+            # fetch dependencies from targets with fetch_always set to true
+            if fetch_objs:
+                fetch_dependencies(output_path, fetch_objs, dep_cache_dir, True, pool)
+
         logger.info("Rendered inventory (%.2fs)", time.time() - rendering_start)
 
         worker = partial(
@@ -620,6 +640,7 @@ def valid_target_obj(target_obj, require_compile=True):
                         "ref": {"type": "string"},
                         "unpack": {"type": "boolean"},
                         "version": {"type": "string"},
+                        "fetch_always": {"type": "boolean"},
                     },
                     "required": ["type", "output_path", "source"],
                     "additionalProperties": False,
@@ -632,6 +653,7 @@ def valid_target_obj(target_obj, require_compile=True):
                                     "source": {"format": "uri"},
                                     "output_path": {},
                                     "unpack": {},
+                                    "fetch_always": {},
                                 },
                                 "additionalProperties": False,
                             },
@@ -646,6 +668,7 @@ def valid_target_obj(target_obj, require_compile=True):
                                     "unpack": {},
                                     "chart_name": {"type": "string"},
                                     "version": {"type": "string"},
+                                    "fetch_always": {},
                                 },
                                 "required": ["type", "output_path", "source", "chart_name"],
                                 "additionalProperties": False,

--- a/tests/test_remote_inventory.py
+++ b/tests/test_remote_inventory.py
@@ -90,7 +90,7 @@ class RemoteInventoryTest(unittest.TestCase):
         rmtree(output_dir)
 
     def test_compile_fetch(self):
-        """Run $ kapitan compile --fetch --output-path=some/dir/ --inventory-path=another/dir --targets remoteinv-example remoteinv-nginx zippedinv --force
+        """Run $ kapitan compile --force-fetch --output-path=some/dir/ --inventory-path=another/dir --targets remoteinv-example remoteinv-nginx zippedinv
         were some/dir/ & another/dir/ are directories chosen by the user
 
         Recursively force fetch inventories and compile
@@ -110,7 +110,7 @@ class RemoteInventoryTest(unittest.TestCase):
         sys.argv = [
             "kapitan",
             "compile",
-            "--fetch",
+            "--force-fetch",
             "--output-path",
             temp_output,
             "--inventory-path",
@@ -119,7 +119,6 @@ class RemoteInventoryTest(unittest.TestCase):
             "remoteinv-example",
             "remoteinv-nginx",
             "zippedinv",
-            "--force",
         ]
         main()
 
@@ -159,10 +158,10 @@ class RemoteInventoryTest(unittest.TestCase):
         rmtree(temp_dir)
 
     def test_force_fetch(self):
-        """Test overwriting inventory items while using the --force flag
+        """Test overwriting inventory items while using the --force-fetch flag
 
         runs $ kapitan compile --fetch --cache --output-path=temp_output --inventory-pat=temp_inv --targets remoteinv-example
-        runs $ kapitan compile --fetch --cache --output-path=temp_output --inventory-pat=temp_inv --targets remoteinv-example --force
+        runs $ kapitan compile --force-fetch --cache --output-path=temp_output --inventory-pat=temp_inv --targets remoteinv-example
         """
 
         temp_output = tempfile.mkdtemp()
@@ -205,7 +204,7 @@ class RemoteInventoryTest(unittest.TestCase):
         sys.argv = [
             "kapitan",
             "compile",
-            "--fetch",
+            "--force-fetch",
             "--cache",
             "--output-path",
             temp_output,
@@ -213,7 +212,6 @@ class RemoteInventoryTest(unittest.TestCase):
             temp_inv,
             "--targets",
             "remoteinv-example",
-            "--force",
         ]
         main()
         # zippedinv.yml overwritten


### PR DESCRIPTION
Fixes issue: #858 
## Proposed Changes
* Added a option to have a `fetch_always`-property in your external dependencies.
    If `fetch_always` is set to `true`, this dependency will always get fetched and overwrite existing files (force-fetch).

* Renamed `--force`-flag to `--force-fetch`, so you have to run
    * ` $ kapitan compile --fetch` to fetch (existing files won't get overwritten) or
    * ` $ kapitan compile --force-fetch` to fetch the dependencies and overwrite existing files.

If the property is false or not given, the default-behavior of the fetch-functionality doesn't change.
Also the behavior of `--fetch` and (now:)`--force-fetch` doesn't change either.

**NOTE:** Using `--force` will still work with its default behavior, but is now a _deprecated_ flag and will be removed soon.

## Documentation and testing
Updated flag-name in the docs and in the tests.
