### PR TITLE
Propagate env vars `$PATH` and `$HOME` for `input_type: external`

### DIFF
--- a/docs/compile.md
+++ b/docs/compile.md
@@ -564,3 +564,10 @@ parameters:
 ```
 
 *Supported output types*: N/A (no need to specify `output_type`)
+
+Additionally, the input type supports field `env_vars`, which can be used to set environment variables for the external command.
+By default, the external command doesn't inherit any environment variables from Kapitan's environment.
+However, if environment variables `$PATH` or `$HOME` aren't set in `env_vars`, they will be propagated from Kapitan's environment to the external command's environment.
+
+Finally, Kapitan will substitute `${compiled_target_dir}` in both the command's arguments and the environment variables.
+This variable needs to be escaped in the configuration to ensure that reclass won't interpret it as a reclass reference.

--- a/kapitan/inputs/external.py
+++ b/kapitan/inputs/external.py
@@ -25,6 +25,13 @@ class External(InputType):
         self.target_name = None
 
     def set_env_vars(self, env_vars):
+        # Propagate HOME and PATH environment variables to external tool
+        # This is necessary, because calling `subprocess.run()` with `env` set doesn't propagate
+        # any environment variables from the current process.
+        if "PATH" not in env_vars:
+            env_vars["PATH"] = os.environ.get("PATH")
+        if "HOME" not in env_vars:
+            env_vars["HOME"] = os.environ.get("HOME")
         self.env_vars = env_vars
 
     def set_args(self, args):


### PR DESCRIPTION
## Summary

For compile objects with `input_type: external`, the external command is executed with `subprocess.run()` with keyword parameter `env`. By providing this keyword parameter, the command will not inherit Kapitan's `os.environ`, as documented in
https://docs.python.org/3/library/subprocess.html:

> If env is not None, it must be a mapping that defines the environment variables for the new process; these are used instead of the default behavior of inheriting the current process’ environment. It is passed directly to Popen.

This commit ensures that we pass `$PATH` and `$HOME` from Kapitan's `os.environ` to the external command unless those environment variables were explicitly set in the compile object's `env_vars`.

## Proposed Changes

  - Propagate environment variables `$PATH` and `$HOME` to external command for `input_type: external` unless explicitly set in the compile object's `env_vars`