### PR TITLE
Added more automatic generator functions (#694)

### DIFF
--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -70,9 +70,9 @@ parameters:
     users:
       root:
         # If 'refs/targets/${target_name}/mysql/password' doesn't exist, it will gen a random b64-encoded password
-        password: ?{gpg:targets/${target_name}/mysql/password||randomstr|base64}
-        # password: ?{gkms:targets/${target_name}/mysql/password||randomstr|base64}
-        # password: ?{awskms:targets/${target_name}/mysql/password||randomstr|base64}
+        password: ?{gpg:targets/${target_name}/mysql/password||random:str|base64}
+        # password: ?{gkms:targets/${target_name}/mysql/password||random:str|base64}
+        # password: ?{awskms:targets/${target_name}/mysql/password||random:str|base64}
 
         # Generates the sha256 checksum of the previously declared B64'ed password
         # It's base64'ed again so that it can be used in kubernetes secrets

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -83,7 +83,12 @@ When referencing your secret in the inventory during compile, you can use the fo
 - `ed25519` - Generates a ed25519 private key (PKCS#8).
 - `publickey` - Derives the public key from a revealed private key i.e. `||reveal:path/to/encrypted_private_key|publickey`
 - `rsapublic` - Derives an RSA public key from a revealed private key i.e. `||reveal:path/to/encrypted_private_key|rsapublic` (deprecated, use `publickey` instead)
-- `loweralphanum` - Generates a DNS-compliant text string (a-z and 0-9), containing lower alphanum chars `||`
+- `randomint` - Generates a random number. You can optionally pass the length you want i.e `||randomint:64`
+- `loweralphanum` - Generates a DNS-compliant text string (a-z and 0-9), containing lower alphanum chars i.e. `||loweralphanum:32`
+- `upperalphanum` - Generates a text string (A-Z and 0-9) containing uppercase letters and numbers i.e. `||upperalphanum:32`
+- `loweralpha` - Generates a text string (a-z) containing lowercase letters i.e. `||loweralpha:32`
+- `upperalpha` - Generates a text string (A-Z) containing uppercase letters i.e. `||upperalpha:32`
+- `alphanumspec` - Generates a text string containing alphanumeric and given special characters i.e. `||alphanumspec:32:!$%&/(){}[]`. default is `string.punctuation`. Note: you can't pass `|` or `:` manually
 
 *Note*: The first operator here `||` is more similar to a logical OR. If the secret file doesn't exist, kapitan will generate it and apply the functions after the `||`. If the secret file already exists, no functions will run.
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -75,20 +75,23 @@ Kapitan will inherit the secrets configuration for the specified target, and enc
 
 When referencing your secret in the inventory during compile, you can use the following functions to automatically generate, encrypt and save your secret:
 
-- `randomstr` - Generates a random string. You can optionally pass the length you want i.e. `||randomstr:32`
-- `base64` - base64 encodes your secret; to be used as a secondary function i.e. `||randomstr|base64`
-- `sha256` - sha256 hashes your secret; to be used as a secondary function i.e. `||randomstr|sha256`. You can optionally pass a salt i.e `||randomstr|sha256:salt` -> becomes `sha256("salt:<generated random string>")`
+- `random` - Generates a random textstring with characters of given pool. Use one of:
+  - `str` : generator function for alphanumeric characters, will be url-token-safe
+  - `int` : generator function for digits (0-9)
+  - `loweralpha` : generator function for lowercase letters (a-z)
+  - `upperalpha` : generator function for uppercase letters (A-Z)
+  - `loweralphanum` : generator function for lowercase letters and numbers (a-z and 0-9)
+  - `upperalphanum` : generator function for uppercase letters and numbers (A-Z and 0-9)
+  - `special` : generator function for alphanumeric characters and given special characters(third parameter)
+
+  You can optionally pass the length you want i.e. `||random:str:32`
+- `base64` - base64 encodes your secret; to be used as a secondary function i.e. `||random:str|base64`
+- `sha256` - sha256 hashes your secret; to be used as a secondary function i.e. `||random:str|sha256`. You can optionally pass a salt i.e `||random:str|sha256:salt` -> becomes `sha256("salt:<generated random string>")`
 - `reveal` - Decrypts a secret; to be used as a secondary function, useful for reuse of a secret like for different encodings i.e `||reveal:path/to/secret|base64`
 - `rsa` - Generates an RSA 4096 private key (PKCS#8). You can optionally pass the key size i.e. `||rsa:2048`
 - `ed25519` - Generates a ed25519 private key (PKCS#8).
 - `publickey` - Derives the public key from a revealed private key i.e. `||reveal:path/to/encrypted_private_key|publickey`
 - `rsapublic` - Derives an RSA public key from a revealed private key i.e. `||reveal:path/to/encrypted_private_key|rsapublic` (deprecated, use `publickey` instead)
-- `randomint` - Generates a random number. You can optionally pass the length you want i.e `||randomint:64`
-- `loweralphanum` - Generates a DNS-compliant text string (a-z and 0-9), containing lower alphanum chars i.e. `||loweralphanum:32`
-- `upperalphanum` - Generates a text string (A-Z and 0-9) containing uppercase letters and numbers i.e. `||upperalphanum:32`
-- `loweralpha` - Generates a text string (a-z) containing lowercase letters i.e. `||loweralpha:32`
-- `upperalpha` - Generates a text string (A-Z) containing uppercase letters i.e. `||upperalpha:32`
-- `alphanumspec` - Generates a text string containing alphanumeric and given special characters i.e. `||alphanumspec:32:!$%&/(){}[]`. default is `string.punctuation`. Note: you can't pass `|` or `:` manually
 
 *Note*: The first operator here `||` is more similar to a logical OR. If the secret file doesn't exist, kapitan will generate it and apply the functions after the `||`. If the secret file already exists, no functions will run.
 
@@ -106,7 +109,7 @@ For example, assume for now that your GPG-encrypted secret is already stored in 
 users:
   root:
     # If 'secrets/targets/${target_name}/mysql/password' doesn't exist, we can automatically generate a random b64-encoded password as follows
-    password: ?{gpg:targets/${target_name}/mysql/password|randomstr|base64}
+    password: ?{gpg:targets/${target_name}/mysql/password||random:str|base64}
 ```
 
 During compile, kapitan will search for the path `targets/${target_name}/mysql/password`. Should it not exist, then it will automatically generate a random base64 password and save it to that path.

--- a/kapitan/refs/base.py
+++ b/kapitan/refs/base.py
@@ -19,7 +19,7 @@ from functools import lru_cache
 import yaml
 
 from kapitan.errors import RefBackendError, RefError, RefFromFuncError, RefHashMismatchError
-from kapitan.refs.functions import eval_func
+from kapitan.refs.functions import eval_func, get_func_lookup
 from kapitan.utils import PrettyDumper, list_all_paths
 
 try:
@@ -592,7 +592,11 @@ class RefController(object):
                 try:
                     eval_func(func_name, ctx, *func_params)
                 except KeyError:
-                    raise RefError(f"{func_name}: unknown ref function used.")
+                    raise RefError(
+                        "{}: unknown ref function used. Choose one of: {}".format(
+                            func_name, [key for key in get_func_lookup()]
+                        )
+                    )
 
         return ctx
 

--- a/kapitan/refs/functions.py
+++ b/kapitan/refs/functions.py
@@ -10,7 +10,6 @@ import hashlib
 import logging
 import secrets  # python secrets module
 import string
-import re
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
@@ -192,15 +191,15 @@ def alphanumspec(ctx, nchars="8", special_chars=string.punctuation):
     default is !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~
     NOTE: '|' and ':' are used for arg parsing and aren't allowed manually, in default they work
     """
-    # make sure that each character is include only once or not at all
+    # make sure that each allowed character is include only once or not at all
     special_chars = "".join(set(special_chars).intersection(string.punctuation))
-    pool = string.ascii_letters + special_chars
+    pool = string.ascii_letters + string.digits + special_chars
     generic_alphanum(ctx, nchars, pool)
 
 
 def generic_alphanum(ctx, nchars, pool):
     """
-    generates a DNS-compliant text string, containing nchars from pool
+    generates a text string, containing nchars from pool
     default for nchars is 8 chars
     sets it to ctx.data
     """
@@ -209,6 +208,10 @@ def generic_alphanum(ctx, nchars, pool):
         nchars = int(nchars)
     except ValueError:
         raise RefError(f"Ref error: eval_func: {nchars} cannot be converted into integer.")
+
+    allowed_pool = string.ascii_letters + string.digits + string.punctuation
+    if not set(pool).issubset(allowed_pool):
+        raise RefError("{}: invalid elements in pool".format(set(pool).difference(set(allowed_pool))))
 
     # generate string based on given pool
     generated_str = "".join(secrets.choice(pool) for i in range(nchars))

--- a/kapitan/refs/functions.py
+++ b/kapitan/refs/functions.py
@@ -47,7 +47,7 @@ def randomstr(ctx, nbytes=""):
     sets it to ctx.data
     """
     # deprecated function
-    logger.info("")
+    logger.info("DeprecationWarning: randomstr is deprecated. Use random:str instead")
     random(ctx, "str", nbytes)
 
 
@@ -148,7 +148,7 @@ def reveal(ctx, secret_path):
 def loweralphanum(ctx, nchars="8"):
     """generates a DNS-compliant text string (a-z and 0-9), containing lower alphanum chars"""
     # deprecated function
-    logger.info("")
+    logger.info("DeprecationWarning: loweralphanum is deprecated. Use random:loweralphanum instead")
     random(ctx, "loweralphanum", nchars)
 
 

--- a/kapitan/refs/functions.py
+++ b/kapitan/refs/functions.py
@@ -195,7 +195,6 @@ def alphanumspec(ctx, nchars="8", special_chars=string.punctuation):
     # make sure that each character is include only once or not at all
     special_chars = "".join(set(special_chars).intersection(string.punctuation))
     pool = string.ascii_letters + special_chars
-    print(pool)
     generic_alphanum(ctx, nchars, pool)
 
 

--- a/kapitan/refs/functions.py
+++ b/kapitan/refs/functions.py
@@ -58,7 +58,7 @@ def sha256(ctx, salt=""):
         ctx.data = hashlib.sha256(salted_input_value.encode()).hexdigest()
     else:
         raise RefError(
-            "Ref error: eval_func: nothing to sha256 hash; try " "something like '|randomstr|sha256'"
+            "Ref error: eval_func: nothing to sha256 hash; try " "something like '|random:str|sha256'"
         )
 
 

--- a/kapitan/refs/functions.py
+++ b/kapitan/refs/functions.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 def eval_func(func_name, ctx, *func_params):
     """calls specific function which generates the secret"""
     func_lookup = get_func_lookup()
-    
+
     return func_lookup[func_name](ctx, *func_params)
 
 
@@ -42,7 +42,7 @@ def get_func_lookup():
         "loweralphanum": lower_alpha_num,
         "upperalpha": upper_alpha,
         "upperalphanum": upper_alpha_num,
-        "customregex": custom_regex
+        "alphanumspec": alphanumspec,
     }
 
 
@@ -185,6 +185,20 @@ def upper_alpha_num(ctx, nchars="8"):
     generic_alphanum(ctx, nchars, pool)
 
 
+def alphanumspec(ctx, nchars="8", special_chars=string.punctuation):
+    """
+    generator function for alphanumeric characters and given special characters
+    usage: ?{base64:path/to/secret||alphanumspec:32:#./&}
+    default is !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~
+    NOTE: '|' and ':' are used for arg parsing and aren't allowed manually, in default they work
+    """
+    # make sure that each character is include only once or not at all
+    special_chars = "".join(set(special_chars).intersection(string.punctuation))
+    pool = string.ascii_letters + special_chars
+    print(pool)
+    generic_alphanum(ctx, nchars, pool)
+
+
 def generic_alphanum(ctx, nchars, pool):
     """
     generates a DNS-compliant text string, containing nchars from pool
@@ -192,26 +206,13 @@ def generic_alphanum(ctx, nchars, pool):
     sets it to ctx.data
     """
     # check input
-    try: 
-        nchars = int (nchars)
+    try:
+        nchars = int(nchars)
     except ValueError:
         raise RefError(f"Ref error: eval_func: {nchars} cannot be converted into integer.")
-    
+
     # generate string based on given pool
     generated_str = "".join(secrets.choice(pool) for i in range(nchars))
 
-    # set ctx.data to generated string 
+    # set ctx.data to generated string
     ctx.data = generated_str
-
-
-def custom_regex(ctx, regex = "***"):
-    """
-    (TBD)
-    generates a text string matching the given regex 
-    example: ...||customregex:("^[a-zA-Z0-9 ,:/\\-]{8}$") could generate "Uk0,rB\w" as secret
-    sets it to ctx.data
-    """
-    # validate regex
-    # generate string
-    # set string to ctx.data
-    raise NotImplementedError

--- a/kapitan/refs/functions.py
+++ b/kapitan/refs/functions.py
@@ -21,8 +21,15 @@ logger = logging.getLogger(__name__)
 
 
 def eval_func(func_name, ctx, *func_params):
+    """calls specific function which generates the secret"""
+    func_lookup = get_func_lookup()
+    
+    return func_lookup[func_name](ctx, *func_params)
 
-    func_lookup = {
+
+def get_func_lookup():
+    """returns the lookup-table for the generator functions"""
+    return {
         "randomstr": randomstr,
         "sha256": sha256,
         "ed25519": ed25519_private_key,
@@ -37,8 +44,6 @@ def eval_func(func_name, ctx, *func_params):
         "upperalphanum": upper_alpha_num,
         "customregex": custom_regex
     }
-
-    return func_lookup[func_name](ctx, *func_params)
 
 
 def randomstr(ctx, nbytes=""):

--- a/kapitan/refs/functions.py
+++ b/kapitan/refs/functions.py
@@ -189,6 +189,14 @@ def random(ctx, type="str", nchars="", special_chars=string.punctuation):
         except ValueError:
             raise RefError(f"Ref error: eval_func: {nchars} cannot be converted into integer.")
 
+    # check if any special characters are specified without using type special
+    if type != "special" and special_chars != string.punctuation:
+        raise RefError(
+            "Ref error: eval_func: {} has no option to use special characters. Use type special instead, i.e. ||random:special:{}".format(
+                type, special_chars
+            )
+        )
+
     # check if pool is valid, eliminates duplicates
     allowed_pool = string.ascii_letters + string.digits + string.punctuation
     pool = "".join(set(pool).intersection(allowed_pool))

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -163,11 +163,11 @@ class Base64RefsTest(unittest.TestCase):
 
     def test_base64_ref_tag_func_name(self):
         "check ref tag func name is correct"
-        tag = "?{base64:my/ref5||randomstr}"
+        tag = "?{base64:my/ref5||random:str}"
         tag, token, func_str = REF_CONTROLLER.tag_params(tag)
-        self.assertEqual(tag, "?{base64:my/ref5||randomstr}")
+        self.assertEqual(tag, "?{base64:my/ref5||random:str}")
         self.assertEqual(token, "base64:my/ref5")
-        self.assertEqual(func_str, "||randomstr")
+        self.assertEqual(func_str, "||random:str")
 
     def test_base64_ref_embedded_attr(self):
         "check embedded ref has embed_refs set to True"
@@ -199,7 +199,7 @@ class Base64RefsTest(unittest.TestCase):
         check new ref tag with function raises RefFromFuncError
         and then creates it using RefParams()
         """
-        tag = "?{base64:my/ref7||randomstr}"
+        tag = "?{base64:my/ref7||random:str}"
         with self.assertRaises(RefFromFuncError):
             REF_CONTROLLER[tag]
         try:
@@ -392,7 +392,7 @@ class Base64RefsTest(unittest.TestCase):
     def test_ref_function_base64(self):
         "write randomstr to ref and base64, confirm ref file exists, reveal and check"
 
-        tag = "?{base64:ref/base64||randomstr|base64}"
+        tag = "?{base64:ref/base64||random:str|base64}"
         REF_CONTROLLER[tag] = RefParams()
         self.assertTrue(os.path.isfile(os.path.join(REFS_HOME, "ref/base64")))
 
@@ -406,7 +406,7 @@ class Base64RefsTest(unittest.TestCase):
     def test_ref_function_sha256(self):
         "write randomstr to ref and sha256, confirm ref file exists, reveal and check"
 
-        tag = "?{base64:ref/sha256||randomstr|sha256}"
+        tag = "?{base64:ref/sha256||random:str|sha256}"
         REF_CONTROLLER[tag] = RefParams()
         self.assertTrue(os.path.isfile(os.path.join(REFS_HOME, "ref/sha256")))
 

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -9,6 +9,7 @@
 
 import base64
 import os
+import string
 import tempfile
 import unittest
 
@@ -440,3 +441,113 @@ class Base64RefsTest(unittest.TestCase):
         REVEALER._reveal_tag_without_subvar.cache_clear()
         revealed = REVEALER.reveal_raw_file(file_with_tags)
         self.assertEqual(len(revealed), 16)
+
+    def test_ref_function_upperalphanum(self):
+        "write upperalphanum to secret, confirm ref file exists, reveal and check"
+
+        tag = "?{plain:ref/upperalphanum||upperalphanum}"
+        REF_CONTROLLER[tag] = RefParams()
+        self.assertTrue(os.path.isfile(os.path.join(REFS_HOME, "ref/upperalphanum")))
+
+        file_with_tags = tempfile.mktemp()
+        with open(file_with_tags, "w") as fp:
+            fp.write("?{plain:ref/upperalphanum}")
+        revealed = REVEALER.reveal_raw_file(file_with_tags)
+        self.assertEqual(len(revealed), 8)  # default length of upperalphanum string is 8
+
+        # Test with parameter nchars=16, correlating with string length 16
+        tag = "?{plain:ref/upperalphanum||upperalphanum:16}"
+        REF_CONTROLLER[tag] = RefParams()
+        REVEALER._reveal_tag_without_subvar.cache_clear()
+        revealed = REVEALER.reveal_raw_file(file_with_tags)
+        self.assertEqual(len(revealed), 16)
+
+    def test_ref_function_loweralpha(self):
+        "write loweralpha to secret, confirm ref file exists, reveal and check"
+
+        tag = "?{plain:ref/loweralpha||loweralpha}"
+        REF_CONTROLLER[tag] = RefParams()
+        self.assertTrue(os.path.isfile(os.path.join(REFS_HOME, "ref/loweralpha")))
+
+        file_with_tags = tempfile.mktemp()
+        with open(file_with_tags, "w") as fp:
+            fp.write("?{plain:ref/loweralpha}")
+        revealed = REVEALER.reveal_raw_file(file_with_tags)
+        self.assertEqual(len(revealed), 8)  # default length of loweralpha string is 8
+
+        # Test with parameter nchars=16, correlating with string length 16
+        tag = "?{plain:ref/loweralpha||loweralpha:16}"
+        REF_CONTROLLER[tag] = RefParams()
+        REVEALER._reveal_tag_without_subvar.cache_clear()
+        revealed = REVEALER.reveal_raw_file(file_with_tags)
+        self.assertEqual(len(revealed), 16)
+
+    def test_ref_function_upperalpha(self):
+        "write upperalpha to secret, confirm ref file exists, reveal and check"
+
+        tag = "?{plain:ref/upperalpha||upperalpha}"
+        REF_CONTROLLER[tag] = RefParams()
+        self.assertTrue(os.path.isfile(os.path.join(REFS_HOME, "ref/upperalpha")))
+
+        file_with_tags = tempfile.mktemp()
+        with open(file_with_tags, "w") as fp:
+            fp.write("?{plain:ref/upperalpha}")
+        revealed = REVEALER.reveal_raw_file(file_with_tags)
+        self.assertEqual(len(revealed), 8)  # default length of upperalpha string is 8
+
+        # Test with parameter nchars=16, correlating with string length 16
+        tag = "?{plain:ref/upperalpha||upperalpha:16}"
+        REF_CONTROLLER[tag] = RefParams()
+        REVEALER._reveal_tag_without_subvar.cache_clear()
+        revealed = REVEALER.reveal_raw_file(file_with_tags)
+        self.assertEqual(len(revealed), 16)
+
+    def test_ref_function_randomint(self):
+        "write randomint to secret, confirm ref file exists, reveal and check"
+
+        tag = "?{plain:ref/randomint||randomint}"
+        REF_CONTROLLER[tag] = RefParams()
+        self.assertTrue(os.path.isfile(os.path.join(REFS_HOME, "ref/randomint")))
+
+        file_with_tags = tempfile.mktemp()
+        with open(file_with_tags, "w") as fp:
+            fp.write("?{plain:ref/randomint}")
+        revealed = REVEALER.reveal_raw_file(file_with_tags)
+        self.assertEqual(len(revealed), 16)  # default length of randomint string is 16
+
+        # Test with parameter nchars=32, correlating with string length 32
+        tag = "?{plain:ref/randomint||randomint:32}"
+        REF_CONTROLLER[tag] = RefParams()
+        REVEALER._reveal_tag_without_subvar.cache_clear()
+        revealed = REVEALER.reveal_raw_file(file_with_tags)
+        self.assertEqual(len(revealed), 32)
+
+    def test_ref_function_alphanumspec(self):
+        "write alphanumspec to secret, confirm ref file exists, reveal and check"
+        tag = "?{plain:ref/alphanumspec||alphanumspec}"
+        REF_CONTROLLER[tag] = RefParams()
+        self.assertTrue(os.path.isfile(os.path.join(REFS_HOME, "ref/alphanumspec")))
+
+        file_with_tags = tempfile.mktemp()
+        with open(file_with_tags, "w") as fp:
+            fp.write("?{plain:ref/alphanumspec}")
+        revealed = REVEALER.reveal_raw_file(file_with_tags)
+        self.assertEqual(len(revealed), 8)  # default length of alphanumspec string is 8
+
+        # Test with parameter nchars=16, correlating with string length 16
+        tag = "?{plain:ref/alphanumspec||alphanumspec:16}"
+        REF_CONTROLLER[tag] = RefParams()
+        REVEALER._reveal_tag_without_subvar.cache_clear()
+        revealed = REVEALER.reveal_raw_file(file_with_tags)
+        self.assertEqual(len(revealed), 16)
+
+        # Test with every allowed special char, nchars=32
+        allowed_special_chars = set(string.punctuation).difference(":|")
+        for special_char in allowed_special_chars:
+            tag = "?{plain:ref/alphanumspec||alphanumspec:32:" + special_char + "}"
+            REF_CONTROLLER[tag] = RefParams()
+            REVEALER._reveal_tag_without_subvar.cache_clear()
+            revealed = REVEALER.reveal_raw_file(file_with_tags)
+            self.assertEqual(len(revealed), 32)
+            intersection = set(string.punctuation).intersection(revealed)
+            self.assertTrue(intersection.issubset(set(special_char)))

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -422,7 +422,7 @@ class Base64RefsTest(unittest.TestCase):
 
     # TODO write tests for RefController errors (lookups, etc..)
 
-    def test_ref_function_loweralphanum(self):
+    def test_ref_function_random_loweralphanum(self):
         "write loweralphanum to secret, confirm ref file exists, reveal and check"
 
         tag = "?{plain:ref/loweralphanum||loweralphanum}"
@@ -442,10 +442,10 @@ class Base64RefsTest(unittest.TestCase):
         revealed = REVEALER.reveal_raw_file(file_with_tags)
         self.assertEqual(len(revealed), 16)
 
-    def test_ref_function_upperalphanum(self):
-        "write upperalphanum to secret, confirm ref file exists, reveal and check"
+    def test_ref_function_random_upperalphanum(self):
+        "write random:upperalphanum to secret, confirm ref file exists, reveal and check"
 
-        tag = "?{plain:ref/upperalphanum||upperalphanum}"
+        tag = "?{plain:ref/upperalphanum||random:upperalphanum}"
         REF_CONTROLLER[tag] = RefParams()
         self.assertTrue(os.path.isfile(os.path.join(REFS_HOME, "ref/upperalphanum")))
 
@@ -456,16 +456,16 @@ class Base64RefsTest(unittest.TestCase):
         self.assertEqual(len(revealed), 8)  # default length of upperalphanum string is 8
 
         # Test with parameter nchars=16, correlating with string length 16
-        tag = "?{plain:ref/upperalphanum||upperalphanum:16}"
+        tag = "?{plain:ref/upperalphanum||random:upperalphanum:16}"
         REF_CONTROLLER[tag] = RefParams()
         REVEALER._reveal_tag_without_subvar.cache_clear()
         revealed = REVEALER.reveal_raw_file(file_with_tags)
         self.assertEqual(len(revealed), 16)
 
     def test_ref_function_loweralpha(self):
-        "write loweralpha to secret, confirm ref file exists, reveal and check"
+        "write random:loweralpha to secret, confirm ref file exists, reveal and check"
 
-        tag = "?{plain:ref/loweralpha||loweralpha}"
+        tag = "?{plain:ref/loweralpha||random:loweralpha}"
         REF_CONTROLLER[tag] = RefParams()
         self.assertTrue(os.path.isfile(os.path.join(REFS_HOME, "ref/loweralpha")))
 
@@ -476,16 +476,16 @@ class Base64RefsTest(unittest.TestCase):
         self.assertEqual(len(revealed), 8)  # default length of loweralpha string is 8
 
         # Test with parameter nchars=16, correlating with string length 16
-        tag = "?{plain:ref/loweralpha||loweralpha:16}"
+        tag = "?{plain:ref/loweralpha||random:loweralpha:16}"
         REF_CONTROLLER[tag] = RefParams()
         REVEALER._reveal_tag_without_subvar.cache_clear()
         revealed = REVEALER.reveal_raw_file(file_with_tags)
         self.assertEqual(len(revealed), 16)
 
     def test_ref_function_upperalpha(self):
-        "write upperalpha to secret, confirm ref file exists, reveal and check"
+        "write random:upperalpha to secret, confirm ref file exists, reveal and check"
 
-        tag = "?{plain:ref/upperalpha||upperalpha}"
+        tag = "?{plain:ref/upperalpha||random:upperalpha}"
         REF_CONTROLLER[tag] = RefParams()
         self.assertTrue(os.path.isfile(os.path.join(REFS_HOME, "ref/upperalpha")))
 
@@ -496,16 +496,16 @@ class Base64RefsTest(unittest.TestCase):
         self.assertEqual(len(revealed), 8)  # default length of upperalpha string is 8
 
         # Test with parameter nchars=16, correlating with string length 16
-        tag = "?{plain:ref/upperalpha||upperalpha:16}"
+        tag = "?{plain:ref/upperalpha||random:upperalpha:16}"
         REF_CONTROLLER[tag] = RefParams()
         REVEALER._reveal_tag_without_subvar.cache_clear()
         revealed = REVEALER.reveal_raw_file(file_with_tags)
         self.assertEqual(len(revealed), 16)
 
     def test_ref_function_randomint(self):
-        "write randomint to secret, confirm ref file exists, reveal and check"
+        "write random:int to secret, confirm ref file exists, reveal and check"
 
-        tag = "?{plain:ref/randomint||randomint}"
+        tag = "?{plain:ref/randomint||random:int}"
         REF_CONTROLLER[tag] = RefParams()
         self.assertTrue(os.path.isfile(os.path.join(REFS_HOME, "ref/randomint")))
 
@@ -516,38 +516,37 @@ class Base64RefsTest(unittest.TestCase):
         self.assertEqual(len(revealed), 16)  # default length of randomint string is 16
 
         # Test with parameter nchars=32, correlating with string length 32
-        tag = "?{plain:ref/randomint||randomint:32}"
+        tag = "?{plain:ref/randomint||random:int:32}"
         REF_CONTROLLER[tag] = RefParams()
         REVEALER._reveal_tag_without_subvar.cache_clear()
         revealed = REVEALER.reveal_raw_file(file_with_tags)
         self.assertEqual(len(revealed), 32)
 
-    def test_ref_function_alphanumspec(self):
-        "write alphanumspec to secret, confirm ref file exists, reveal and check"
-        tag = "?{plain:ref/alphanumspec||alphanumspec}"
+    def test_ref_function_special(self):
+        "write random:special to secret, confirm ref file exists, reveal and check"
+        tag = "?{plain:ref/special||random:special}"
         REF_CONTROLLER[tag] = RefParams()
-        self.assertTrue(os.path.isfile(os.path.join(REFS_HOME, "ref/alphanumspec")))
+        self.assertTrue(os.path.isfile(os.path.join(REFS_HOME, "ref/special")))
 
         file_with_tags = tempfile.mktemp()
         with open(file_with_tags, "w") as fp:
-            fp.write("?{plain:ref/alphanumspec}")
+            fp.write("?{plain:ref/special}")
         revealed = REVEALER.reveal_raw_file(file_with_tags)
-        self.assertEqual(len(revealed), 8)  # default length of alphanumspec string is 8
+        self.assertEqual(len(revealed), 8)  # default length of special string is 8
 
         # Test with parameter nchars=16, correlating with string length 16
-        tag = "?{plain:ref/alphanumspec||alphanumspec:16}"
+        tag = "?{plain:ref/special||random:special:16}"
         REF_CONTROLLER[tag] = RefParams()
         REVEALER._reveal_tag_without_subvar.cache_clear()
         revealed = REVEALER.reveal_raw_file(file_with_tags)
         self.assertEqual(len(revealed), 16)
 
         # Test with every allowed special char, nchars=32
-        allowed_special_chars = set(string.punctuation).difference(":|")
-        for special_char in allowed_special_chars:
-            tag = "?{plain:ref/alphanumspec||alphanumspec:32:" + special_char + "}"
-            REF_CONTROLLER[tag] = RefParams()
-            REVEALER._reveal_tag_without_subvar.cache_clear()
-            revealed = REVEALER.reveal_raw_file(file_with_tags)
-            self.assertEqual(len(revealed), 32)
-            intersection = set(string.punctuation).intersection(revealed)
-            self.assertTrue(intersection.issubset(set(special_char)))
+        allowed_special_chars = "".join(set(string.punctuation).difference(":|"))
+        tag = "?{plain:ref/special||random:special:32:" + allowed_special_chars + "}"
+        REF_CONTROLLER[tag] = RefParams()
+        REVEALER._reveal_tag_without_subvar.cache_clear()
+        revealed = REVEALER.reveal_raw_file(file_with_tags)
+        self.assertEqual(len(revealed), 32)
+        intersection = set(string.punctuation).intersection(revealed)
+        self.assertTrue(intersection.issubset(set(allowed_special_chars)))


### PR DESCRIPTION
Fixes issue #694

## Proposed Changes
**New generic `random` function:**
Generates a random string based on given parameters.
### Usage
```yaml
secret: ?{ref:path/to/secret||random:type:nchars:special}
```
The first parameter `type` has to be one of:
* `str` : generator function for alphanumeric characters, will be url-token-safe
* `int` : generator function for digits (0-9)
* `loweralpha` : generator function for lowercase letters (a-z)
* `upperalpha` : generator function for uppercase letters (A-Z)
* `loweralphanum` : generator function for lowercase letters and numbers (a-z and 0-9)
* `upperalphanum` : generator function for uppercase letters and numbers (A-Z and 0-9)
* `special` : generator function for alphanumeric characters and given special characters

I'm always open for name suggestions.

All these types have in common, that the second parameter `nchars` indicates how many characters the generated secret contains.
The default value for this is
  * `random:str` : 43 characters
  * `random:int` : 16 characters
  * other : 8 characters

The `special` type has a third argument that indicates which special characters are allowed for the generation.
The default for that is `string.punctuation` (``!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~``).

**NOTE:** in manual usage the characters `|` and `:` are used for function and argument parsing, so they can't be specified.

This might be a 
## Breaking change
To pass special characters into the generator pool, we have to change the **REF_TOKEN_TAG_PATTERN**-regex.
The new regex `(\?{(\w+:[\w\-\.\@\=\/\:]+)(\|(?:(?:\|\w+)(?::\S*)*)+)?\=*})` matches all existing use cases, but is more restricted.
So be beware of unexpected errors.

Furthermore the existing generator functions `randomstr` and `lowernumalpha` are still working and still behave the same.
But they will be removed soon.

## Examples
Here are some example cases with expected output:
* Tag: `?{ref:path/to/secret||random:int}` generates a secret containing 16 (default) digits, i.e. `1254872907909324`
* Tag: `?{ref:path/to/secret||random:upperalphanum:12}` generates a secret containing 12 chars from uppercase letters and numbers, i.e. `VUPA0GIO47C2`
* Tag: `?{ref:path/to/secret||random:special:16:!$%&}` generates a secret containing 16 chars from alphanumeric letters and given special characters `!$%&`, i.e. `!kQT&m%csSDsdaBy`

You could leave the argument empty, so `?{ref:path/to/secret||random:special:12:}` generates a alphanumeric string without any special characters.

## Documentation and testing
* Updated Tests
* **TBD:** Update docs for latest iteration.

## Minor Issue
tl;dr: Some errors don't get caught and could produce some unexpected behavior.
See detailed: https://github.com/kapicorp/kapitan/issues/694#issuecomment-1277919468
