### PR TITLE
Raise kadet module loading errors

### DIFF
--- a/kapitan/inputs/kadet.py
+++ b/kapitan/inputs/kadet.py
@@ -125,12 +125,22 @@ class Kadet(InputType):
         kadet_arg_spec = inspect.getfullargspec(kadet_module.main)
         logger.debug("Kadet main args: %s", kadet_arg_spec.args)
 
-        if len(kadet_arg_spec.args) == 1:
-            output_obj = kadet_module.main(input_params)
-        elif len(kadet_arg_spec.args) == 0:
-            output_obj = kadet_module.main()
-        else:
+        if len(kadet_arg_spec.args) > 1:
             raise ValueError(f"Kadet {spec.name} main parameters not equal to 1 or 0")
+
+        try:
+            if len(kadet_arg_spec.args) == 1:
+                output_obj = kadet_module.main(input_params)
+            elif len(kadet_arg_spec.args) == 0:
+                output_obj = kadet_module.main()
+        except Exception as e:
+            # Re raise kadet module CompileError
+            if type(e) is CompileError:
+                raise
+            # Print traceback on any other errors
+            else:
+                logger.exception("\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
+                raise CompileError(f"Could not load Kadet module: {spec.name[16:]}")
 
         output_obj = _to_dict(output_obj)
         if prune:

--- a/kapitan/inputs/kadet.py
+++ b/kapitan/inputs/kadet.py
@@ -133,14 +133,10 @@ class Kadet(InputType):
                 output_obj = kadet_module.main(input_params)
             elif len(kadet_arg_spec.args) == 0:
                 output_obj = kadet_module.main()
-        except Exception as e:
-            # Re raise kadet module CompileError
-            if type(e) is CompileError:
-                raise
-            # Print traceback on any other errors
-            else:
-                logger.exception("\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
-                raise CompileError(f"Could not load Kadet module: {spec.name[16:]}")
+        except Exception:
+            # Log traceback and exception as is
+            logger.exception("")
+            raise CompileError(f"Could not load Kadet module: {spec.name[16:]}")
 
         output_obj = _to_dict(output_obj)
         if prune:

--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -177,7 +177,7 @@ def compile_targets(
         logger.debug("Compile pool terminated")
         # only print traceback for errors we don't know about
         if not isinstance(e, KapitanError):
-            logger.exception("Unknown (Non-Kapitan) Error occurred")
+            logger.exception("\nUnknown (Non-Kapitan) error occurred:\n")
 
         logger.error("\n")
         if kwargs.get("verbose"):


### PR DESCRIPTION
Adds a fix to properly raise kadet module loading errors on compile. Prints traceback when exception is not CompileError.

Fixes issue #857 

