### PR TITLE
Add markdown linter to pre-commit

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -12,6 +12,7 @@ A clear and concise description of what the bug/feature request is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -23,10 +24,11 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable, add screenshots to help explain your problem/idea.
 
-** If it's a bug (please complete the following information):**
- - `python --version`:
- - `pip3 --version`: 
- - `Are you using pyenv or virtualenv?`
+**If it's a bug (please complete the following information):**
+
+- `python --version`:
+- `pip3 --version`:
+- `Are you using pyenv or virtualenv?`
 
 **Additional context**
 Add any other context about the problem here.

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -2,5 +2,10 @@
 default: true
 MD013:
   line_length: 600
+MD024:
+  siblings_only: true
+MD033:
+  allowed_elements:
+    - "img"
 no-hard-tabs: false
 whitespace: false

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,6 @@
+---
+default: true
+MD013:
+  line_length: 600
+no-hard-tabs: false
+whitespace: false

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,3 +1,4 @@
 examples/
 tests/
 kapitan/
+PULL_REQUEST_TEMPLATE.md

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,3 @@
+examples/
+tests/
+kapitan/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,10 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: stable
+    rev: 22.10.0
     hooks:
     - id: black
       language_version: python3.7
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.32.2
+    hooks:
+    - id: markdownlint-fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## 0.30.0-rc.0:
+# CHANGELOG
+
+## 0.30.0-rc.0
+
 - Helm binary support (KAP 09) (#701) special thanks @Jean-Daniel @sebradloff @srueg
 - Gojsonnet support (#753) special thanks @pvanderlinden @janeklb
 - Fix searchvar not finding vars with false values (#670) thanks @roman8422
@@ -12,7 +15,8 @@
 - Bump httplib2 from 0.18.1 to 0.19.0 (#692)
 - Ignore copy file on missing source (#687) thanks @ademariag
 
-## 0.29.5:
+## 0.29.5
+
 - Note for jsonnet on arm. Skip import if not used (#663)
 - Fix error for null inventory path in kadet (#664)
 - Bump jsonnet from 0.16.0 to 0.17.0 (#665)
@@ -22,8 +26,8 @@
 - Handle KeyError in kapitan secrets/refs (#681)
 - Find release version script
 
+## 0.29.4
 
-## 0.29.4:
 - Fix inventory_path not found error (#661)
 - Bump requests from 2.24.0 to 2.25.0 (#657)
 - Bump boto3 from 1.15.10 to 1.16.26 (#654)
@@ -34,24 +38,28 @@
 - Bump cryptography to fix CVE-2020-25659 (#636)
 - Add libssl for static(x) binary (#628)
 
-## 0.29.3:
+## 0.29.3
+
 - Bump boto3 from 1.14.52 to 1.15.10 (#619)
 - VAULT_SKIP_VERIFY supports with yaml boolean defined in parameters (#623)
 - Add staticx and patchelf to pyinstaller.sh to build a Linux static binary (#624)
 - remove inventory_path parameter in InputType classes (#625)
 
-## 0.29.2:
+## 0.29.2
+
 - Fix for reveal of secret for dir with json (#607)
 - Fix FileExistsError when fetching multiple dependencies with unpack=True (#608)
 - Create External Input (#587)
 - Update reclass dependency (#610)
 - Bump yamllint from 1.24.2 to 1.25.0 (#616)
 
-## 0.29.1:
+## 0.29.1
+
 - Fix reveal from ref file bug (#605)
 - Update dependencies (#600, #601, #602, #603)
 
-## 0.29.0:
+## 0.29.0
+
 - Fix issue #572 Enable adding reclass classes from remote inventories before they are available (#574)
 - Add a dedicated directory in the temp path (#584)
 - Fix issue with dynamically created array of pointers with cffi (#586)
@@ -68,34 +76,41 @@
 - Add TOML Jinja2 Filters (#534)
 - Fix issues #535 and #536 by resolving relative paths in the copy input type and not clobbering the output dir (#539)
 
-## 0.29.0-rc.2:
+## 0.29.0-rc.2
+
 - Fix issue #572 Enable adding reclass classes from remote inventories before they are available (#574)
 - Add a dedicated directory in the temp path (#584)
 - Fix issue with dynamically created array of pointers with cffi (#586)
 - New remove input type (#589)
 - Update pip dependencies (#578, #580, #581, #577, #576, #582)
 
-## 0.29.0-rc.1:
+## 0.29.0-rc.1
+
 - Rename remote inventory key to `inventory` instead of `inventories` (#570)
 
-## 0.29.0-rc.0:
+## 0.29.0-rc.0
+
 - Add support for remote inventory fetching (#521)
 
-## 0.28.1-rc.4:
+## 0.28.1-rc.4
+
 - Adds input_params for compile time parameter injection into kadet modules (#560)
 - Add logging fix for python 3.8+ on macOS (#559)
 - Allow reclass override none feature (#562)
 - Update python dependencies (#555, #556, #557)
 
-## 0.28.1-rc.3:
+## 0.28.1-rc.3
+
 - Enable helm values files to be injected for input type "helm" (#545)
 - Fix issue #500: Add --ref-file or --tag to refs --reveal option. (#548)
 
-## 0.28.1-rc.0:
+## 0.28.1-rc.0
+
 - Add TOML Jinja2 Filters (#534)
 - Fix issues #535 and #536 by resolving relative paths in the copy input type and not clobbering the output dir (#539)
 
-## 0.28.0:
+## 0.28.0
+
 - Update reclass and some pip dependencies. (#528)
 - Allow using .yaml output file extension along with .yml (#525)
   - Note: if you have .yaml files in your inventory instead of .yml, now kapitan should recognise them as expected. If you see changes in your compiled output just rename your .yaml files to .yml to keep the compiled diff identical.
@@ -104,22 +119,27 @@
 - adding dir_files_list and dir_files_read in jsonnet (#519)
 - Add file_exists function to jsonnet (#518)
 
-## 0.28.0-rc.2:
+## 0.28.0-rc.2
+
 - Update reclass and some pip dependencies. (#528)
 
-## 0.28.0-rc.1:
+## 0.28.0-rc.1
+
 - Allow using .yaml output file extension along with .yml (#525)
 
-## 0.28.0-rc.0:
+## 0.28.0-rc.0
+
 - Fix embedded refs encoding value (#523)
 - Add new Helm dependency input type (#520)
 - adding dir_files_list and dir_files_read in jsonnet (#519)
 - Add file_exists function to jsonnet (#518)
 
-## 0.27.4:
+## 0.27.4
+
 - Fix linter argument flag to refs-path instead of deprecated secrets-path (#516)
 
-## 0.27.3:
+## 0.27.3
+
 - Fix Vaultkv Error Handling (#512)
 - Fix Running init with kapitan binary doesn't work (#514)
 - Show traceback to explain source of the issue (#507)
@@ -127,38 +147,47 @@
 - Update pip dependencies to latest versions (#504)
 - Compile refs in embedded format (#502)
 
-## 0.27.3-rc.3:
+## 0.27.3-rc.3
+
 - Fix Vaultkv Error Handling (#512)
 - Fix Running init with kapitan binary doesn't work (#514)
 
-## 0.27.3-rc.2:
+## 0.27.3-rc.2
+
 - Show traceback to explain source of the issue (#507)
 - Handle function calling logic in argparse instead of using equals (#509)
 
-## 0.27.3-rc.1:
+## 0.27.3-rc.1
+
 - Update pip dependencies to latest versions (#504)
 
-## 0.27.3-rc.0:
+## 0.27.3-rc.0
+
 - Compile refs in embedded format (#502)
 
-## 0.27.2:
+## 0.27.2
+
 - Check if input obj is None before writing to disk (#485)
 
-## 0.27.1:
+## 0.27.1
+
 - Display full path of target after compilation (#464)
 - Always re-pull dependencies with --fetch (#465)
 - Support search paths in jinja2 (#474)
 - This release might add extra whitespace to some of your jinja2 generated configurations.
 
-## 0.27.1-rc.0:
+## 0.27.1-rc.0
+
 - Display full path of target after compilation (#464)
 - Always re-pull dependencies with --fetch (#465)
 - Support search paths in jinja2 (#474)
 
-## 0.27.0:
+## 0.27.0
+
 - Update all dependency versions
 
-## 0.26.1:
+## 0.26.1
+
 - Enable prune, per compile target (#451)
 - Install net-tools in CI Image
 - Fix issue #434 Output as a string does not interpolate secrets (#438)
@@ -167,49 +196,60 @@
 - Add key info for RefBackendError for easier debugging (#439)
 - Update python dependencies to latest versions (#447)
 
-## 0.26.1-rc.2:
+## 0.26.1-rc.2
+
 - Enable prune, per compile target (#451)
 
-## 0.26.1-rc.1:
+## 0.26.1-rc.1
+
 - Fix issue #434 Output as a string does not interpolate secrets (#438)
 - Upgrade to Cloud SDK version 274.0.0 (#441)
 - Fix issue #445: Explicitly create directories for all outputted CompiledFile objects. (#446)
 - Add key info for RefBackendError for easier debugging (#439)
 - Update python dependencies to latest versions (#447)
 
-## 0.26.0:
+## 0.26.0
+
 - Fix issue #431: jsonnet compile fails for a single string that isn't an object with items in it. (#432)
 - Fix input_paths globbing when search paths are defined (#426)
 - Support for ed25519 public/private keys in refs (#422)
 - New copy input type (#423)
 
-## 0.26.0-rc.1:
+## 0.26.0-rc.1
+
 - Fix input_paths globbing when search paths are defined (#426)
 
-## 0.26.0-rc.0:
+## 0.26.0-rc.0
+
 - Support for ed25519 public/private keys in refs (#422)
 - New copy input type (#423)
 
-## 0.25.5:
+## 0.25.5
+
 - add input_paths globbing support (#419)
 - add kap.yaml_load_stream() function (#416)
 - new yaml_dump_stream() native jsonnet function (#415)
 - Add mysql client, openssh-client to Dockerfile.ci (#413)
 
-## 0.25.4:
+## 0.25.4
+
 - Add bsdmainutils to Dockerfile.ci
 
-## 0.25.3:
+## 0.25.3
+
 - Update Dockerfile.ci to debian 10, latest terraform, gcloud sdk and docker (#406)
 
-## 0.25.2:
+## 0.25.2
+
 - Update wrong path for binaries (#400)
 - Fix template for kapitan init so that the results compiles out of the box (#403)
 
-## 0.25.1:
+## 0.25.1
+
 - Add jsonnet back to dockerfile.ci (#398)
 
-## 0.25.0:
+## 0.25.0
+
 - Add support for revealing files in subdirectories (#386)
 - Upgrade to TF 0.12.10 in Dockerfile.ci (#391)
 - Label selectors for compilation (#388)
@@ -223,38 +263,46 @@
 - Fix Helm binding errors in docker (#359)
 - Restore old order in compile_targets to fix process fork issue (#396)
 
-#### Breaking:
+### Breaking
+
 For these breaking changes, run `./scripts/kap_5_migrate.py` to help you migrate the majority of secrets.
 
 - Move to Kap5 ref types (#334)
 - Fix issue #277: Change first '|' operator in secrets functions with '||' (#382)
 
-## 0.25.0-rc.2:
+## 0.25.0-rc.2
+
 - Add support for revealing files in subdirectories (#386)
 - Upgrade to TF 0.12.10 in Dockerfile.ci (#391)
 - Label selectors for compilation (#388)
 - Normalise helm compile (#385)
 
-## 0.25.0-rc.1:
+## 0.25.0-rc.1
+
 - Jsonschema function for jsonnet (#380)
 - Fix issue 381: Document .kapitan and update jsonnet, git and hvac dependencies (#383)
 - Vault secret backend added - read-only (#310)
 
-#### Breaking:
+### Breaking
+
 - Move to Kap5 ref types (#334)
 - Fix issue #277: Change first '|' operator in secrets functions with '||' (#382)
 
-## 0.24.1-rc.3:
+## 0.24.1-rc.3
+
 - Add yq to the docker images (#375)
 
-## 0.24.1-rc.2:
+## 0.24.1-rc.2
+
 - Update all Dockerfiles to use multi-stage builds (#370)
 
-## 0.24.1-rc.1:
+## 0.24.1-rc.1
+
 - Add additional content type header for fetching GZIP files (#364)
 - Fix Helm binding errors in docker (#359)
 
-## 0.24.0:
+## 0.24.0
+
 - Add standalone binary to github releases
 - Upgrade some packages in requirements.txt (#344)
 - Upgrade kapp and kbld to v0.11.0 (#344)
@@ -273,36 +321,43 @@ For these breaking changes, run `./scripts/kap_5_migrate.py` to help you migrate
 - Add kapp and kbld to kapitan-ci (#314)
 - Implement secret sub-variables (#282)
 
-## 0.24.0-rc.6:
+## 0.24.0-rc.6
+
 - Testing github release of standalone binary
 
-## 0.24.0-rc.4:
+## 0.24.0-rc.4
+
 - Upgrade some packages in requirements.txt (#344)
 - Upgrade kapp and kbld to v0.11.0 (#344)
 - Fix dependency manager's behavior for files to unpack (#342)
 - creating standalone binary for kapitan (#323)
 
-## 0.24.0-rc.3:
+## 0.24.0-rc.3
+
 - Add reveal_maybe custom jinja2 filter (#332)
 - Add support to import Helm input type (#307)
 
-## 0.24.0-rc.2:
+## 0.24.0-rc.2
+
 - Make boto3 requirement more flexible (#320)
 - Add kubernetes manifest validation (#317)
 - Improve json schema validation error display for inventory (#318)
 - Multi-document yaml outputs (#308)
 
-## 0.24.0-rc.1:
+## 0.24.0-rc.1
+
 - Add external dependency management (#304)
 
-## 0.24.0-rc.0:
+## 0.24.0-rc.0
+
 - Fix bug in resources.py when passing config to reclass (#296)
 - Fix requests version to circumvent urllib3 version conflict (#300)
 - Upgrade to jsonnet 0.13.0 (#309)
 - Add kapp and kbld to kapitan-ci (#314)
 - Implement secret sub-variables (#282)
 
-## 0.23.1:
+## 0.23.1
+
 - Fix pypi package by including requirements.txt (#287)
 - Make jsonnet & kadet support plain text output_type (#288)
 - Fallback to reclass 1.5.6 because of regression (#284)
@@ -310,15 +365,18 @@ For these breaking changes, run `./scripts/kap_5_migrate.py` to help you migrate
 - Add support for specifying custom jinja2 filters (#267)
 - Update minor dependencies (#283)
 
-## 0.23.1-rc.1:
+## 0.23.1-rc.1
+
 - Fallback to reclass 1.5.6 because of regression (#284)
 
-## 0.23.1-rc.0:
+## 0.23.1-rc.0
+
 - Add parseYaml function in jsonnet (#263)
 - Add support for specifying custom jinja2 filters (#267)
 - Update reclass (1.6.0) and other minor dependencies (#283)
 
-## 0.23.0:
+## 0.23.0
+
 - Add support for writing ref type secrets in cli (#242)
 - Validate target name matches target yml file name (#243)
 - randomstr now generates exactly as many characters as requested (#245)
@@ -330,60 +388,76 @@ For these breaking changes, run `./scripts/kap_5_migrate.py` to help you migrate
 - Removed ujson dependency (#220)
 - Tests for terraform compile (#225)
 
-#### Breaking:
+### Breaking
+
 - Fixed and updated kapitan version checking (#233)
 
-## 0.23.0-rc.2:
+## 0.23.0-rc.2
+
 - Add support for writing ref type secrets in cli (#242)
 - Validate target name matches target yml file name (#243)
 - randomstr now generates exactly as many characters as requested (#245)
 - Add yamllint in kapitan linter checks (#246)
 
-## 0.23.0-rc.1:
+## 0.23.0-rc.1
+
 - Added more jinja2 filters (#234)
 - Improved tests coverage (#236)
 
-## 0.23.0-rc.0:
-#### Breaking:
+## 0.23.0-rc.0
+
+### Breaking
+
 - Fixed and updated kapitan version checking (#233)
 
-## 0.22.4-rc.1:
+## 0.22.4-rc.1
+
 - Fix included input templates (#229)
 
-## 0.22.4-rc.0:
+## 0.22.4-rc.0
+
 - Added kapitan init (#213)
 - Removed ujson dependency (#220)
 - Tests for terraform compile (#225)
 
-## 0.22.3:
+## 0.22.3
+
 - Fixed bug in secrets --validate-targets and --update-targets (#207)
 
-## 0.22.2 (secrets validation broken, do not use):
+## 0.22.2 (secrets validation broken, do not use)
+
 - Fixed failing docker builds and added it to the tests (#204)
 - Update google api python client (#204)
 
-## 0.22.1 (secrets validation broken, do not use):
+## 0.22.1 (secrets validation broken, do not use)
+
 - Added some basic linter functionality (kapitan linter -h) (#193)
 - Added support for Kadet input type (python, still a beta feature) (#190)
 
-## 0.22.0:
-#### Updates:
+## 0.22.0
+
+### Updates
+
 - Updated python dependencies: pyyaml and six
 - Added AWS KMS support as a secrets backend (#179)
 - Refactor input\_type code into classes (#180)
 - Fix GPG failing when expiry of gpg key is infinite (#181)
 
-#### Breaking:
+### Breaking
+
 - Added reveal secrets function, updated rsapublic function (#182)
 - parameters.kapitan.secrets.recipients is deprecated, please use parameters.kapitan.secrets.gpg.recipients (#183)
 
-## 0.21.0:
-- Upgraded to jsonnet 0.12.1 (https://github.com/google/jsonnet/releases/tag/v0.12.1)
+## 0.21.0
 
-## 0.20.1:
+- Upgraded to jsonnet 0.12.1 (<https://github.com/google/jsonnet/releases/tag/v0.12.1>)
+
+## 0.20.1
+
 - Added jinja2 base64 filter (#170)
 
-## 0.20.0:
+## 0.20.0
+
 - Fix re.sub hanging (#158)
 - gCloud KMS secrets backend (#159)
 - Support .yaml in refs (#160)
@@ -393,80 +467,100 @@ For these breaking changes, run `./scripts/kap_5_migrate.py` to help you migrate
 - gkms update and validate secrets (#167)
 - Added promtool to CI image (#168)
 
-## 0.20.0-rc.2:
+## 0.20.0-rc.2
+
 - Travis, Docker and requirements updates (#166)
 - gkms update and validate secrets (#167)
 
-## 0.20.0-rc.1:
+## 0.20.0-rc.1
+
 - Better kapitan version checking (#163)
 - Secrets fixes (#165)
 
-## 0.20.0-rc.0:
+## 0.20.0-rc.0
+
 - gCloud KMS secrets backend (#159)
 - Fix re.sub hanging (#158)
 - Support .yaml in refs (#160)
 
-## 0.19.0:
+## 0.19.0
+
 - Fix cli secrets (#154)
 - Add python_requires (#149) - thanks @Code0x58
 - update reclass to release v1.5.6 (#146)
 - Secrets restructure (#148)
 
-## 0.18.2:
+## 0.18.2
+
 - Fixed `gzip_b64` determinism
 
-## 0.18.1:
+## 0.18.1
+
 - Dependencies update (#137)
 - Made cache an optional flag (`--cache`). Support for additional cache paths (`--cache-paths`) (#138)
 - Small fix in caching (#140)
 - Added `gzip_b64` jsonnet function to support gzip compression of strings + base64
 - Added Python 3.7 support
 
-## 0.18.0:
-#### Breaking:
+## 0.18.0
+
+### Breaking
+
 - Renamed `--search-path` to `--search-paths` in `eval` and `compile`, enabling multiple paths for jsonnet/jinja2 and adding support for [jsonnet bundler](https://github.com/jsonnet-bundler/jsonnet-bundler) (#133)
 
-#### Updates:
+### Updates
+
 - Inventory and folders caching; only compile targets that changed (#134)
 - Updated reclass to v1.5.5 (#135)
 - Updated jsonnet to v0.11.2 (#136)
 
-## 0.17.1:
+## 0.17.1
+
 - Command flags support in .kapitan (#125)
 - Upgraded reclass to 1.5.4 (#127)
 - Added `rsapublic` function to gpg backend (#128)
 
-## 0.17.0:
-#### Breaking:
+## 0.17.0
+
+### Breaking
+
 - `kapitan compile` does not prune jsonnet output anymore by default (#118). `--no-prune` flag has been removed and replaced with `--prune`. If you want to keep jsonnet output consistent with <0.17.0, you can do `kapitan compile --prune`.
 
-#### Updates:
+### Updates
+
 - Add pretty printer (`-p`) option to searchvar (#121)
 - Cleaned up examples (#123)
 - Updated requests to 2.19.1 (#124)
 
-## 0.16.11:
+## 0.16.11
+
 - Updated RSA key format to PKCS#8 (#120)
 
-## 0.16.10:
+## 0.16.10
+
 - GPG backend cleanup (no change in usage or cli) (#116)
 - Improved caching (#117)
 - Verbose options for `inventory` and `searchvar` commands (#119)
 
-## 0.16.9:
+## 0.16.9
+
 - Fixed bug with searchvar keys chain (#115)
 
-## 0.16.8:
+## 0.16.8
+
 - Reclass submodule integration fixes
 
-## 0.16.5:
+## 0.16.5
+
 - Reclass update (#112)
 
-## 0.16.4:
+## 0.16.4
+
 - Fixed deep_get recursion and search (#108)
 - Customizable indentation of yaml/json (#110)
 
-## 0.16.3:
+## 0.16.3
+
 - Allow recursive search and globbing in searchvar and inventory commands (#97)
 - terraform in CI image (#98)
 - Updated kube.libjsonnet and fixed secrets example (#101)
@@ -477,36 +571,44 @@ For these breaking changes, run `./scripts/kap_5_migrate.py` to help you migrate
   - SHA256 function `?{gpg:mysql/root/password|randomstr|sha256}`
   - Deprecated `|randomstrb64` in favor of `|randomstr|base64`
 
-## 0.16.2:
+## 0.16.2
+
 - Do not escape forward slashes in `json.dump` (#92)
 - sha256 jsonnet function (#94)
 
-## 0.16.1:
+## 0.16.1
+
 - Fix for #81
 - Clearer message for version check (#82)
 - Support for jinja2 'do' extension (#89)
 
-## 0.16.0:
+## 0.16.0
+
 - Updated reclass
-- (https://github.com/deepmind/kapitan/pull/78) Support for creating a target secret on compile time, if the secret does not already exist:
-```
+- (<https://github.com/deepmind/kapitan/pull/78>) Support for creating a target secret on compile time, if the secret does not already exist:
+
+```yaml
 ?{gpg:path/to/new_secret|randomstr:32}
 ```
+
 If `path/to/new_secret` does not exist under `secrets_path` it evaluates `randomstr:32`, which returns a 32 byte-log random string generated by [secrets.token_urlsafe](https://docs.python.org/3/library/secrets.html#secrets.token_urlsafe) and creates the secret with its content.
-- (https://github.com/deepmind/kapitan/pull/79) Support for YAML C bindings to improve compilation performance.
+
+- (<https://github.com/deepmind/kapitan/pull/79>) Support for YAML C bindings to improve compilation performance.
 
 If you're using the pip version of Kapitan, you can benefit from YAML C bindings support by running:
 
 Linux: `sudo apt-get install python3-yaml`
 Mac: `brew install libyaml`
 
-## 0.15.0:
+## 0.15.0
+
 - Updates to `deepmind/kapitan:ci` Docker image
 - `kapitan secrets --write` and `kapitan secrets --update-targets` are now consistent in terms of the recipients list #67
 - Significant performance improvement to `kapitan compile` #71
 - `kapitan compile` now writes the version to `.kapitan` and future executions will check if the last used kapitan version is <= than the current kapitan version, to keep compilations consistent. You can skip version check by doing `kapitan compile --ignore-version-check`. For more info see #57 and #72
 
-## 0.14.0:
+## 0.14.0
+
 - Kapitan now requires python 3.6
 - Fixed dockerfile to ensure delegated volumes (#47)
 - Fixed missing target compiled directory
@@ -514,51 +616,61 @@ Mac: `brew install libyaml`
 - gnupg updated to 0.4.2
 - Inventory target pattern command parsing improvements
 
-## 0.13.0:
-- Added --pattern feature to inventory cli (https://github.com/deepmind/kapitan/issues/41)
-- now using python3 lru_cache instead of memoize
-- fixed searchvar (https://github.com/deepmind/kapitan/issues/40)
+## 0.13.0
 
-## 0.12.0:
+- Added --pattern feature to inventory cli (<https://github.com/deepmind/kapitan/issues/41>)
+- now using python3 lru_cache instead of memoize
+- fixed searchvar (<https://github.com/deepmind/kapitan/issues/40>)
+
+## 0.12.0
+
 - moved to python 3 (python 2 should still work but no longer supported)
 - updated to jsonnet v0.10.0
 - new yaml jinja2 filter
-- target secrets support (https://github.com/deepmind/kapitan/pull/36)
+- target secrets support (<https://github.com/deepmind/kapitan/pull/36>)
 - more tests
 
-## 0.11.0:
+## 0.11.0
+
 - Supports compiling specific targets
 - Breaking change: non inventory target files are gone
 
-## 0.10.0:
+## 0.10.0
+
 - Supports reading targets from the inventory as well as target files
 - Breaking change: the keys in compile items changed, see (#22)
 
-## 0.9.19:
+## 0.9.19
+
 - checks for gpg key expiry
 - allow base64 encoding content for secrets
 - support for revealing files in directories
 
-## 0.9.18:
+## 0.9.18
+
 - fixes a bug that overwrites the output_path if it is set to '.'
 
-## 0.9.17:
-- breaking change: the compile command will compile all targets found (https://github.com/deepmind/kapitan/pull/16)
-- log/print friendlier error messages avoiding tracebacks for known failure behaviours (https://github.com/deepmind/kapitan/pull/15) (fixes https://github.com/deepmind/kapitan/issues/11)
+## 0.9.17
 
-## 0.9.16:
+- breaking change: the compile command will compile all targets found (<https://github.com/deepmind/kapitan/pull/16>)
+- log/print friendlier error messages avoiding tracebacks for known failure behaviours (<https://github.com/deepmind/kapitan/pull/15>) (fixes <https://github.com/deepmind/kapitan/issues/11>)
+
+## 0.9.16
+
 - gpg secrets support
 - compiled secret tags
 - new --reveal flag for compile sub-command
 - new --no-verify for secrets sub-command
 - new yaml_dump() native jsonnet function
 
-## 0.9.15:
+## 0.9.15
+
 - Documentation Improvements
 - New --version flag
 - Now using jsonnet 0.9.5
 - inventory_global in jinja and jsonnet
 - Packaged lib/kapitan.libjsonnet
 
-## 0.9.14:
+## 0.9.14
+
 Initial public version

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -2,7 +2,6 @@
 
 Here are some project ideas for GSoC 2020
 
-
 ## 1. Remote Inventory Federation
 
 Description: This work would add the ability to Kapitan to fetch parts of the Inventory from remote locations (https/git). This would allow users to combine different inventories from different sources and build modular infrastructure reusable across various repos.
@@ -16,7 +15,7 @@ Difficulty: Medium
 
 ## 2. Follow up on helm OSX Bindings
 
-Description: This would be a followup project from last years GSoC to complete the helm bindings pipelines so they also build bindings for OSX. https://github.com/kapicorp/kapitan/pull/359 Along with the bindings, it should be possible/fairly easy to also compile the binary of Kapitan for OSX with the bindings prebaked in it.
+Description: This would be a followup project from last years GSoC to complete the helm bindings pipelines so they also build bindings for OSX. <https://github.com/kapicorp/kapitan/pull/359> Along with the bindings, it should be possible/fairly easy to also compile the binary of Kapitan for OSX with the bindings prebaked in it.
 
 Expected Outcome: The pip python package for Kapitan ships with pre-included OSX helm bindings. Documentation is updated and the build is implemented in a way that runs automatically and doesn't require a lot of human time. Along with this, the student would also ship the OSX binary of Kapitan in the github releases page.
 As a bonus, this work could also add a brew manifest for OSX so that users there can install Kapitan in a simpler way.
@@ -30,7 +29,7 @@ Description: Currently kapitan is packaged in pypi (or as a binary) along with a
 
 Adding more input types or secret backends means adding extra dependencies which might not be useful or acceptable for certain users (due to license?).
 This project would be about modularizing of kapitan to a set of core dependencies (cryptography,pyyaml,jsonschema etc) and then extra modules (e.g. boto3,google-api-python-client) that can be loaded by users that actually use those specific features.
-https://docs.python.org/3/library/imp.html might be one of the ways to do that.
+<https://docs.python.org/3/library/imp.html> might be one of the ways to do that.
 
 Expected Outcome: The pypi Kapitan package now contains the minimum set of dependencies and the pipelines on Github build extra packages with any extended functionality like (AWS Key backend, Google KMS Key Backend, Vault Key backend etc)
 Skills required: Python, understanding packaging/modularization, some scripting for automating the pipelines
@@ -38,7 +37,7 @@ Difficulty: Medium
 
 ## 4. Implement Azure KMS and Vault KMS backends
 
-Description: Currently there is a PR to add Azure KMS support to Kapitan https://github.com/kapicorp/kapitan/pull/410 but it needs some adjustments, as well as a methodology to mock the KMS APIs during tests in python. There is also some work done on adding Hashicorp's Vault as a secrets backend https://github.com/kapicorp/kapitan/blob/master/docs/kap_proposals/kap_6_hashicorp_vault.md but that is only implemented for reading values from vaultkv.
+Description: Currently there is a PR to add Azure KMS support to Kapitan <https://github.com/kapicorp/kapitan/pull/410> but it needs some adjustments, as well as a methodology to mock the KMS APIs during tests in python. There is also some work done on adding Hashicorp's Vault as a secrets backend <https://github.com/kapicorp/kapitan/blob/master/docs/kap_proposals/kap_6_hashicorp_vault.md> but that is only implemented for reading values from vaultkv.
 
 This project would be about finalizing all work related to the Azure KMS backend, adding tests + mocks for the Azure/Google/AWS secret backends and finally adding read/write support for the Vault secrets backend.
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,6 @@ Fixes issue #
 
 ## Proposed Changes
 
-  -
-  -
-  -
+-
+-
+-

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Kapitan: Generic templated configuration management for Kubernetes, Terraform and other things
 
 ![Unit Tests](https://github.com/kapicorp/kapitan/actions/workflows/test.yml/badge.svg)
-![](https://img.shields.io/github/pipenv/locked/python-version/kapicorp/kapitan.svg)
-![](https://img.shields.io/pypi/dm/kapitan)
-![](https://img.shields.io/docker/pulls/kapicorp/kapitan)
+![Python Version](https://img.shields.io/github/pipenv/locked/python-version/kapicorp/kapitan.svg)
+![Downloads](https://img.shields.io/pypi/dm/kapitan)
+![Docker Pulls](https://img.shields.io/docker/pulls/kapicorp/kapitan)
 [![Docker](https://github.com/kapicorp/kapitan/workflows/Docker%20Build%20and%20Push/badge.svg)](https://github.com/kapicorp/kapitan/actions?query=workflow%3A%22Docker+Build+and+Push%22)
 [![Releases](https://img.shields.io/github/release/kapicorp/kapitan.svg)](https://github.com/kapicorp/kapitan/releases)
 [![Docker Image Size](https://img.shields.io/docker/image-size/kapicorp/kapitan/latest.svg)](https://hub.docker.com/r/kapicorp/kapitan)
@@ -13,6 +13,7 @@ Kapitan is the tool to help you manage the complexity of your configuration usin
 Use Kapitan to build an inventory which you can then use to drive templates for your Kubernetes manifests, your documentation, your Terraform configuration or even simplify your scripts.
 
 ## Community
+
 * **Main Blog, articles and tutorials**: [Kapitan Blog](https://medium.com/kapitan-blog)
 * [**Generators**](https://medium.com/kapitan-blog/keep-your-ship-together-with-kapitan-d82d441cc3e7) and reference kapitan repository: [Kapitan Reference](https://github.com/kapicorp/kapitan-reference)
 * [Kapitan Reference](https://github.com/kapicorp/kapitan-reference): our reference repository to get started with Kapitan.
@@ -28,56 +29,62 @@ How is it different from [`helm`](https://github.com/kubernetes/helm) and [`kust
 ## Key Concepts
 
 ### Inventory
+
 The inventory is the heart of Kapitan.
-Using simple reusable `yaml` files (classes), you can represent as a ***single source of truth*** 
+Using simple reusable `yaml` files (classes), you can represent as a ***single source of truth***
 everything that matters in your setup, for instance:
- * kubernetes `components` definitions
- * terraform resources
- * business concepts
- * documentation and tooling
- * ...anything else you want!
+
+* kubernetes `components` definitions
+* terraform resources
+* business concepts
+* documentation and tooling
+* ...anything else you want!
   
  Once you have it defined, you can reuse this data to feed into any of the many templating backends available to Kapitan.
 
 ### [**Generators**](https://medium.com/kapitan-blog/keep-your-ship-together-with-kapitan-d82d441cc3e7)
+
 The simplest way to get started with Kapitan.
-Generators are ***universal templates*** that are a simplified way to generate configuration 
-files (for instance, Kubernetes manifests) without using any templating at all. 
+Generators are ***universal templates*** that are a simplified way to generate configuration
+files (for instance, Kubernetes manifests) without using any templating at all.
 > Check out our reference repository to get started:  [Kapitan Reference](https://github.com/kapicorp/kapitan-reference)
 
 > Read our blog post [**Keep your ship together with Kapitan**](https://medium.com/kapitan-blog/keep-your-ship-together-with-kapitan-d82d441cc3e7)
 
 ### [Jsonnet](https://jsonnet.org/) or [Kadet](https://kapitan.dev/compile/#kadet) templates backends
+
 For more complex scenarios, you have a choice of directly using our 2 main templating engines.
 
 You can use either [Jsonnet](https://jsonnet.org/) (tapping into an ever growing number of libraries and examples) or our Python based [Kadet](https://kapitan.dev/compile/#kadet) to create json/yaml based configurations (e.g. Kubernetes, Terraform);
 
 ### [Jinja2](http://jinja.pocoo.org/)
+
 Good old Jinja to create text based templates for scripts and documentation; Don't underestimate the power of this very simple approach to create templated scripts and documentation!
 
 ### [Kapitan Declarative Secrets](https://medium.com/kapitan-blog/declarative-secret-management-for-gitops-with-kapitan-b3c596eab088)
+
 Use Kapitan to securely generate and manage secrets with GPG, AWS KMS, gCloud KMS and Vault.
 
 Use [Tesoro](https://github.com/kapicorp/tesoro), our Kubernetes Admission Controller, to complete your integration with Kubernetes for secure secret decryption on-the-fly.
 
 ## Quickstart
 
-#### Docker (recommended)
+### Docker (recommended)
 
-```
+```shell
 docker run -t --rm -v $(pwd):/src:delegated kapicorp/kapitan -h
 ```
 
 On Linux you can add `-u $(id -u)` to `docker run` to preserve file permissions.
 
-#### Pip
+### Pip
 
 Kapitan needs Python 3.7.
 
 **Install Python 3.7:**
 
- * Linux: `sudo apt-get update && sudo apt-get install -y python3.7-dev python3-pip python3-yaml`
- * Mac: `brew install python3 libyaml`
+* Linux: `sudo apt-get update && sudo apt-get install -y python3.7-dev python3-pip python3-yaml`
+* Mac: `brew install python3 libyaml`
 
 **Install Kapitan:**
 
@@ -95,7 +102,7 @@ sudo pip3 install --upgrade kapitan
 
 ## Example
 
-The example below _compiles_ 2 targets inside the `examples/kubernetes` folder.
+The example below *compiles* 2 targets inside the `examples/kubernetes` folder.
 Each target represents a different namespace in a minikube cluster.
 
 These targets generate the following resources:
@@ -126,23 +133,23 @@ Compiled minikube-es
 
 ### Getting Started
 
-- [Kapitan Overview](docs/kapitan_overview.md)
-- [Understanding inventory](docs/inventory.md)
-- [Compile operation](docs/compile.md)
+* [Kapitan Overview](docs/kapitan_overview.md)
+* [Understanding inventory](docs/inventory.md)
+* [Compile operation](docs/compile.md)
 
 ### Kapitan features
 
-- [References (formerly secrets)](docs/secrets.md)
-- [Manifest validation](docs/validate.md)
-- [External dependencies management](docs/external_dependencies.md)
+* [References (formerly secrets)](docs/secrets.md)
+* [Manifest validation](docs/validate.md)
+* [External dependencies management](docs/external_dependencies.md)
 
 ### Miscellaneous
 
-- [Usage](docs/usage.md)
+* [Usage](docs/usage.md)
 
 ### Examples
 
-- [Kubernetes](docs/example-kubernetes.md)
+* [Kubernetes](docs/example-kubernetes.md)
 
 ## Credits
 
@@ -166,6 +173,7 @@ We quickly discovered that `Helm` did not fit well with our workflow, for the fo
 In short, we feel `Helm` is trying to be `apt-get` for Kubernetes charts, while we are trying to take you further than that.
 
 ### Why do I need Kapitan?
+
 With Kapitan, we worked to de-compose several problems that most of the other solutions are treating as one.
 
 1) ***Kubernetes manifests***: We like the jsonnet approach of using json as the working language. Jsonnet allows us to use inheritance and composition, and hide complexity at higher levels.
@@ -182,7 +190,6 @@ With Kapitan, we worked to de-compose several problems that most of the other so
 We feel most other solutions are pushing the limits of their capacity in order to provide for the above problems.
 Helm treats everything as a text template, while jsonnet tries to do everything as json.
 We believe that these approaches can be blended in a powerful new way, glued together by the inventory.
-
 
 ## Related projects
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,9 @@
 # Kapitan: Generic templated configuration management for Kubernetes, Terraform and other things
 
 ![Unit Tests](https://github.com/kapicorp/kapitan/actions/workflows/test.yml/badge.svg)
-![](https://img.shields.io/github/pipenv/locked/python-version/kapicorp/kapitan.svg)
-![](https://img.shields.io/pypi/dm/kapitan)
-![](https://img.shields.io/docker/pulls/kapicorp/kapitan)
+![Pyhton version](https://img.shields.io/github/pipenv/locked/python-version/kapicorp/kapitan.svg)
+![Downloads](https://img.shields.io/pypi/dm/kapitan)
+![Docker Pulls](https://img.shields.io/docker/pulls/kapicorp/kapitan)
 [![Docker](https://github.com/kapicorp/kapitan/workflows/Docker%20Build%20and%20Push/badge.svg)](https://github.com/kapicorp/kapitan/actions?query=workflow%3A%22Docker+Build+and+Push%22)
 [![Releases](https://img.shields.io/github/release/kapicorp/kapitan.svg)](https://github.com/kapicorp/kapitan/releases)
 [![Docker Image Size](https://img.shields.io/docker/image-size/kapicorp/kapitan/latest.svg)](https://hub.docker.com/r/kapicorp/kapitan)
@@ -13,6 +13,7 @@ Kapitan is the tool to help you manage the complexity of your configuration usin
 Use Kapitan to build an inventory which you can then use to drive templates for your Kubernetes manifests, your documentation, your Terraform configuration or even simplify your scripts.
 
 ## Community
+
 * **Main Blog, articles and tutorials**: [Kapitan Blog](https://medium.com/kapitan-blog)
 * [**Generators**](https://medium.com/kapitan-blog/keep-your-ship-together-with-kapitan-d82d441cc3e7) and reference kapitan repository: [Kapitan Reference](https://github.com/kapicorp/kapitan-reference)
 * [Kapitan Reference](https://github.com/kapicorp/kapitan-reference): our reference repository to get started with Kapitan.
@@ -28,43 +29,49 @@ How is it different from [`helm`](https://github.com/kubernetes/helm) and [`kust
 ## Key Concepts
 
 ### Inventory
-The inventory is the heart of Kapitan. 
-Using simple reusable `yaml` files (classes), you can represent as a ***single source of truth*** 
+
+The inventory is the heart of Kapitan.
+Using simple reusable `yaml` files (classes), you can represent as a ***single source of truth***
 everything that matters in your setup, for instance:
- * kubernetes `components` definitions
- * terraform resources
- * business concepts
- * documentation and tooling
- * ...anything else you want!
+
+* kubernetes `components` definitions
+* terraform resources
+* business concepts
+* documentation and tooling
+* ...anything else you want!
   
  Once you have it defined, you can reuse this data to feed into any of the many templating backends available to Kapitan.
- 
+
 ### [**Generators**](https://medium.com/kapitan-blog/keep-your-ship-together-with-kapitan-d82d441cc3e7)
-The simplest way to get started with Kapitan. 
-Generators are ***universal templates*** that are a simplified way to generate configuration 
-files (for instance, Kubernetes manifests) without using any templating at all. 
+
+The simplest way to get started with Kapitan.
+Generators are ***universal templates*** that are a simplified way to generate configuration
+files (for instance, Kubernetes manifests) without using any templating at all.
 > Check out our reference repository to get started:  [Kapitan Reference](https://github.com/kapicorp/kapitan-reference)
 
-> Read our blog post [**Keep your ship together with Kapitan**](https://medium.com/kapitan-blog/keep-your-ship-together-with-kapitan-d82d441cc3e7) 
+> Read our blog post [**Keep your ship together with Kapitan**](https://medium.com/kapitan-blog/keep-your-ship-together-with-kapitan-d82d441cc3e7)
 
 ### [Jsonnet](https://jsonnet.org/) or [Kadet](https://github.com/kapicorp/kapitan/pull/190) templates backends
+
 For more complex scenarios, you have a choice of directly using our 2 main templating engines.
 
 You can use either [Jsonnet](https://jsonnet.org/) (tapping into an ever growing number of libraries and examples) or our Python based [Kadet](https://github.com/kapicorp/kapitan/pull/190) to create json/yaml based configurations (e.g. Kubernetes, Terraform);
 
 ### [Jinja2](http://jinja.pocoo.org/)
+
 Good old Jinja to create text based templates for scripts and documentation; Don't underestimate the power of this very simple approach to create templated scripts and documentation!
 
 ### [Kapitan Declarative Secrets](https://medium.com/kapitan-blog/declarative-secret-management-for-gitops-with-kapitan-b3c596eab088)
+
 Use Kapitan to securely generate and manage secrets with GPG, AWS KMS, gCloud KMS and Vault.
 
 Use [Tesoro](https://github.com/kapicorp/tesoro), our Kubernetes Admission Controller, to complete your integration with Kubernetes for secure secret decryption on-the-fly.
 
 ## Quickstart
 
-#### Docker (recommended)
+### Docker (recommended)
 
-```
+```shell
 docker run -t --rm -v $(pwd):/src:delegated kapicorp/kapitan -h
 ```
 
@@ -76,8 +83,8 @@ Kapitan needs Python 3.6.
 
 **Install Python 3.6:**
 
- * Linux: `sudo apt-get update && sudo apt-get install -y python3.6-dev python3-pip python3-yaml`
- * Mac: `brew install python3 libyaml`
+* Linux: `sudo apt-get update && sudo apt-get install -y python3.6-dev python3-pip python3-yaml`
+* Mac: `brew install python3 libyaml`
 
 **Install Kapitan:**
 
@@ -95,7 +102,7 @@ sudo pip3 install --upgrade kapitan
 
 ## Example
 
-The example below _compiles_ 2 targets inside the `examples/kubernetes` folder.
+The example below *compiles* 2 targets inside the `examples/kubernetes` folder.
 Each target represents a different namespace in a minikube cluster.
 
 These targets generate the following resources:
@@ -126,23 +133,23 @@ Compiled minikube-es
 
 ### Getting Started
 
-- [Kapitan Overview](kapitan_overview.md)
-- [Understanding inventory](inventory.md)
-- [Compile operation](compile.md)
+* [Kapitan Overview](kapitan_overview.md)
+* [Understanding inventory](inventory.md)
+* [Compile operation](compile.md)
 
 ### Kapitan features
 
-- [References (formerly secrets)](secrets.md)
-- [Manifest validation](validate.md)
-- [External dependencies management](external_dependencies.md)
+* [References (formerly secrets)](secrets.md)
+* [Manifest validation](validate.md)
+* [External dependencies management](external_dependencies.md)
 
 ### Miscellaneous
 
-- [Usage](usage.md)
+* [Usage](usage.md)
 
 ### Examples
 
-- [Kubernetes](example-kubernetes.md)
+* [Kubernetes](example-kubernetes.md)
 
 ## Credits
 
@@ -166,6 +173,7 @@ We quickly discovered that `Helm` did not fit well with our workflow, for the fo
 In short, we feel `Helm` is trying to be `apt-get` for Kubernetes charts, while we are trying to take you further than that.
 
 ### Why do I need Kapitan?
+
 With Kapitan, we worked to de-compose several problems that most of the other solutions are treating as one.
 
 1) ***Kubernetes manifests***: We like the jsonnet approach of using json as the working language. Jsonnet allows us to use inheritance and composition, and hide complexity at higher levels.
@@ -182,7 +190,6 @@ With Kapitan, we worked to de-compose several problems that most of the other so
 We feel most other solutions are pushing the limits of their capacity in order to provide for the above problems.
 Helm treats everything as a text template, while jsonnet tries to do everything as json.
 We believe that these approaches can be blended in a powerful new way, glued together by the inventory.
-
 
 ## Related projects
 

--- a/docs/compile.md
+++ b/docs/compile.md
@@ -2,10 +2,9 @@
 
 **Note:** make sure to read up on [inventory](inventory.md) before moving on.
 
+## Phases of the compile command
 
-### Phases of the compile command
-
-Now that we have a basic understanding of Kapitan `inventory`, we can talk about the `kapitan compile` command. 
+Now that we have a basic understanding of Kapitan `inventory`, we can talk about the `kapitan compile` command.
 
 The command has five distinct `phases`:
 
@@ -106,7 +105,7 @@ Note: unlike jinja2 templates, one jsonnet template can output multiple files (o
 
 Typical jsonnet files would start as follows:
 
-```
+```json
 local kap = import "lib/kapitan.libjsonnet";
 local inventory = kap.inventory();
 ```
@@ -115,7 +114,7 @@ The first line is required to access the kapitan inventory values.
 
 On the second line, `inventory()` callback is used to initialise a local variable through which inventory values for this target can be referenced. For example, the script below
 
-```
+```json
 local kap = import "lib/kapitan.libjsonnet";
 local inventory = kap.inventory();
 
@@ -133,7 +132,7 @@ If your jsonnet is not a dictionary, but is a valid json(net) object, then the o
 
 In addition, importing `kapitan.libjsonnet` makes available the following native_callback functions gluing reclass to jsonnet (amongst others):
 
-```
+```json
 yaml_load - returns a json string of the specified yaml file
 yaml_load_stream - returns a list of json strings of the specified yaml file
 yaml_dump - returns a string yaml from a json string
@@ -148,11 +147,12 @@ gzip_b64 - returns base64 encoded gzip of obj
 inventory - returns a dictionary with the inventory for target
 jsonschema - validates obj with schema, returns object with 'valid' and 'reason' keys
 ```
+
 ##### Jsonschema validation from jsonnet
 
 Given the follow example inventory:
 
-```
+```yaml
 mysql:
   storage: 10G
   storage_class: standard
@@ -161,7 +161,7 @@ mysql:
 
 The yaml inventory structure can be validated with the new `jsonschema()` function:
 
-```
+```json
 local schema = {
     type: "object",
     properties: {
@@ -179,7 +179,7 @@ If `validation.valid` is not true, it will then fail compilation and display `va
 
 For example, if defining the `storage` value with an invalid pattern (`10Z`), compile fails:
 
-```
+```shell
 Jsonnet error: failed to compile /code/components/mysql/main.jsonnet:
  RUNTIME ERROR: '10Z' does not match '^[0-9]+[MGT]{1}$'
 
@@ -198,7 +198,7 @@ Compile error: failed to compile target: minikube-mysql
 
 The following jsonnet snippet renders the jinja2 template in `templates/got.j2`:
 
-```
+```json
 local kap = import "lib/kapitan.libjsonnet";
 
 {
@@ -218,14 +218,14 @@ The following functions are provided by the class `BaseObj()`.
 
 Method definitions:
 
-* `new()`: Provides parameter checking capabilities
-* `body()`: Enables in-depth parameter configuration
+- `new()`: Provides parameter checking capabilities
+- `body()`: Enables in-depth parameter configuration
 
 Method functions:
 
-* `root()`: Defines values that will be compiled into the output
-* `need()`: Ability to check & define input parameters
-* `update_root()`: Updates the template file associated with the class
+- `root()`: Defines values that will be compiled into the output
+- `need()`: Ability to check & define input parameters
+- `update_root()`: Updates the template file associated with the class
 
 A class can be a resource such as a kubernetes Deployment as shown here:
 
@@ -277,6 +277,7 @@ For a deeper understanding of this input type please review the proposal documen
 *Supported output types:*
 
 - yaml (default)
+
 - json
 
 #### using kadet for "post processing" or "overlaying" manifests (alpha/experimental)
@@ -289,6 +290,7 @@ check it into your repository. This could make it harder to upgrade chart versio
 understand the motivation behind changes in the chart itself.
 
 Instead, you could create a kadet module that compiles after the helm input has compiled.
+
 ```yaml
 parameters:
   test_1:
@@ -299,14 +301,14 @@ parameters:
       input_type: helm
       output_path: ${test_1:output_path}
       input_paths:
-      	- <chart_path>
+        - <chart_path>
       helm_values:
         <object_with_values_to_override>
       helm_values_files:
         - <values_file_path>
       helm_params:
-	name: <chart_release_name>
-      	namespace: <substitutes_.Release.Namespace>
+        name: <chart_release_name>
+        namespace: <substitutes_.Release.Namespace>
     - name: add-metadata-test-1
       input_type: kadet
       output_path: ${test_1:output_path}
@@ -316,10 +318,11 @@ parameters:
         team_name: ops
         post_process_inputs: [template-helm-chart]
 ```
+
 Here you can clearly define the order in which your manifests are compiled and ensure that the helm
 chart is templated before your kadet module is run. The `input_params` injected are available in
 the main function as an object. `input_params` will always have the `compile_path` which is the absolute
-path to the compile directory where manifests are compiled on the current run. Any additional keys 
+path to the compile directory where manifests are compiled on the current run. Any additional keys
 placed on the `input_params` in the compile block can be accessed in the kadet module for that specific
 compile run.
 
@@ -394,9 +397,7 @@ Special flags:
       namespace: {{ .Release.Namespace }} # or any other custom values
     ```
 
-
 See the [helm doc](https://helm.sh/docs/helm/helm_template/) for further detail.
-
 
 #### Example
 
@@ -404,7 +405,7 @@ Let's use [nginx-ingress](https://github.com/helm/charts/tree/master/stable/ngin
 
 *On a side note, `https://helm.nginx.com/stable/` is the chart repository URL which you would `helm repo add`, and this repository should contain `index.yaml` that lists out all the available charts and their URLs. By locating this `index.yaml` file, you can locate all the charts available in the repository.*
 
-We can use version 0.3.3 found at https://helm.nginx.com/stable/nginx-ingress-0.3.3.tgz. We can create a simple target file as `inventory/targets/nginx-from-chart.yml` whose content is as follows:
+We can use version 0.3.3 found at <https://helm.nginx.com/stable/nginx-ingress-0.3.3.tgz>. We can create a simple target file as `inventory/targets/nginx-from-chart.yml` whose content is as follows:
 
 ```yaml
 parameters:
@@ -511,6 +512,7 @@ parameters:
 ```
 
 As a reminder, each input block within the compile array is run sequentially for a target in Kapitan. If we reversed the order of the inputs above like so:
+
 ```yaml
 parameters:
   target_name: removal

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -34,7 +34,7 @@ repository, you need to pull it separately by executing the command below:
 git submodule update --init
 ```
 
-#### Troubleshoot pip install errors
+### Troubleshoot pip install errors
 
 Check if gcc is installed:
 
@@ -61,13 +61,13 @@ python3 -m unittest tests/test_vault_transit.py
 To make sure you adhere to the [Style Guide for Python (PEP8)](http://python.org/dev/peps/pep-0008/)
 Python Black is used to apply the formatting so make sure you have it installed with `pip3 install black`.
 
-#### Apply via Git hook
+### Apply via Git hook
 
 - Run `pip3 install pre-commit` to install precommit framework.
 - In the Kapitan root directory, run `pre-commit install`
 - Git add/commit any changed files you want.
 
-#### Apply manually
+### Apply manually
 
 Run `make format_codestyle` before submitting.
 
@@ -94,7 +94,7 @@ Submit a PR for our master branch that updates the `.md` file(s). Test how the c
 
 Once the above PR has been merged, use `mkdocs gh-deploy` command to push the commit that updates the site content to your own gh-pages branch. Make sure that you already have this gh-pages branch in your fork that is up-to-date with our gh-pages branch such that the two branches share the commit history (otherwise Github would not allow PRs to be created).
 
-```
+```text
 # locally, on master branch (which has your updated docs)
 COMMIT_MSG="your commit message to replace" make mkdocs_gh_deploy
 ```

--- a/docs/example-kubernetes.md
+++ b/docs/example-kubernetes.md
@@ -1,12 +1,12 @@
 # Kubernetes example
 
-Here, we walk through how kapitan could be used to help create kubernetes manifests, whose values are customized for each target according to the inventory structure. The example folder can be found in our repository on Github at https://github.com/kapicorp/kapitan/tree/master/examples/kubernetes.
+Here, we walk through how kapitan could be used to help create kubernetes manifests, whose values are customized for each target according to the inventory structure. The example folder can be found in our repository on Github at <https://github.com/kapicorp/kapitan/tree/master/examples/kubernetes>.
 
 ## Directory structure
 
 The following tree shows what this directory looks like (only showing tree level 1):
 
-```
+```text
 ├── components
 ├── docs
 ├── inventory
@@ -22,7 +22,7 @@ We will describe the role of each folder in the following sections.
 
 This folder contains the inventory values used to render the templates for each target. The structure of this folder is as follows:
 
-```
+```text
 .
 ├── classes
 │   ├── cluster
@@ -98,7 +98,7 @@ Don't confuse the `components` folder with `inventory/classes/components` folder
 
 This folder contains the template files as discussed above, typically jsonnet and kadet files. The tree of this directory looks as follows:
 
-```
+```text
 .
 ├── elasticsearch
 │   ├── elasticsearch.container.jsonnet
@@ -119,7 +119,7 @@ Notice how the directory structure corresponds to that of `inventory/classes/com
 
 As mentioned above, we know that the target **minikube-nginx** inherits from `component.namespace`. Let's take a look at `components/namespace/main.jsonnet`:
 
-```
+```json
 local kube = import "lib/kube.libjsonnet";
 local kap = import "lib/kapitan.libjsonnet";
 local inventory = kap.inventory();
@@ -135,7 +135,7 @@ The first two lines import libjsonnet files under `lib` folder: this is the fold
 
 The actual object defined in `components/namespace/main.jsonnet` looks like this:
 
-```
+```json
 {
     "00_namespace": kube.Namespace(p.namespace),
     "10_serviceaccount": kube.ServiceAccount("default")

--- a/docs/example-terraform.md
+++ b/docs/example-terraform.md
@@ -1,6 +1,6 @@
 # Terraform example
 
-We will be looking at how to use Kapitan to compile terraform files with Jsonnet as the input type. It's possible to use other input types, however, Jsonnet is recommended. 
+We will be looking at how to use Kapitan to compile terraform files with Jsonnet as the input type. It's possible to use other input types, however, Jsonnet is recommended.
 For example, we could use the Kadet input to generate terraform files but this would require templates to be written in YAML then rendered into JSON.
 It is possible to allow Kadet to consume JSON as an input. This enables you to integrate your organizations pre-existing terraform JSON file's as templates.
 Jsonnet is the most straightforward input type as you will see due to its functional nature. The only appropriate output type is JSON since this is the format that Terraform consumes.
@@ -8,19 +8,20 @@ Jsonnet is the most straightforward input type as you will see due to its functi
 ## Directory structure
 
 There are several examples available in `examples/terraform`. This will be our working directory for this documentation. The directory structure is as follows:
-```
+
+```text
 ├── inventory
 └── templates
 ```
 
-It is possible to further extend this locally to include a `lib` directory where a `terraform.libjsonnet` file can be stored for use. This is generally dependent on the project scope and organizational patterns. 
+It is possible to further extend this locally to include a `lib` directory where a `terraform.libjsonnet` file can be stored for use. This is generally dependent on the project scope and organizational patterns.
 We will describe in more detail the role of each of these folders in the following sections.
 
 ### inventory
 
 This folder contains the inventory files used to render the templates for each target. The structure of this folder is as follows:
 
-```
+```text
 .
 ├── classes
 │   ├── env
@@ -45,7 +46,7 @@ The `targets` directory enables us to define various projects. We can specify ea
 
 The following is an example targets file. `type.terraform` is what defines the entry point into the main Jsonnet template file. The parameters in the file `inventory/targets/develop/project1.yml` will then be utilized to set the environmental specific provider/resource configuration.
 We define the default region and zone for terraform's provider configuration. The default DNS TTL for the DNS resource is also configured for the development environment.
- 
+
 ```yaml
 classes:
   - type.terraform
@@ -73,7 +74,7 @@ class_mappings:
   - prod/*                             env.prod
   - sandbox/*                          env.sandbox
 ```
- 
+
 The following class `provider.gcp` will be found in all files in this path since it is a common configuration for the cloud authentication module.
 
 ```yaml
@@ -81,7 +82,7 @@ classes:
   - provider.gcp
 ```
 
-Further classes that group parameters together can be included. To assist in further refining the configuration. 
+Further classes that group parameters together can be included. To assist in further refining the configuration.
 
 ### components
 
@@ -90,7 +91,7 @@ You can have these in any path just ensure you define that path in `inventory/cl
 
 The templates folder is where the Jsonnet is located in this instance as shown below:
 
-```
+```text
 .
 ├── cloudbuild.jsonnet
 ├── dns.jsonnet
@@ -125,7 +126,7 @@ The main thing to understand about terraform components is that they are strictl
 }
 ```
 
-Each Jsonnet file defines a resource and then it is imported. Jsonnet then filters through all the inventory parameters to find specific keys that have been defined. Let's take for example the cloud build resource: 
+Each Jsonnet file defines a resource and then it is imported. Jsonnet then filters through all the inventory parameters to find specific keys that have been defined. Let's take for example the cloud build resource:
 
 ```json5
 local cloudbuild = import "cloudbuild.jsonnet";
@@ -138,9 +139,9 @@ local cloudbuild = import "cloudbuild.jsonnet";
 }
 ```  
 
-Assuming that one of the configuration files for a specific environment has the parameter key `cloudbuild` set. 
-These parameters will then be interpreted by the `cloudbuild.jsonnet` template. 
-A file named `cloudbuild.tf.json` will then be compiled using the parameters associated with the `cloudbuild` parameter key. 
+Assuming that one of the configuration files for a specific environment has the parameter key `cloudbuild` set.
+These parameters will then be interpreted by the `cloudbuild.jsonnet` template.
+A file named `cloudbuild.tf.json` will then be compiled using the parameters associated with the `cloudbuild` parameter key.
 
 It is important to understand that once you have a deeper understanding of Kapitan's capabilities, you can organize these files to a style and logic suitable for your organization.
 
@@ -170,7 +171,7 @@ The following is what generates the documentation:
 
 The function `kap.jinja2_template()` (imported from `kapitan.libjsonnet`) is used to convert and interpreter the `README.md.j2` file into a raw string using the inventory for evaluation logic.
 
-Based on the various parameters jinja2 decides which sections of the readme should be included. 
+Based on the various parameters jinja2 decides which sections of the readme should be included.
 When terraform runs it will use the output module to generate your desired `README.md` using information from terraform's state.
 
 Scripts are located in the `scripts` directory. They are compiled using jinja2 as the templating language. An example is as follows:
@@ -181,7 +182,7 @@ export OUTPUT_DIR=$(realpath -m ${DIR}/../../../output/{{inventory.parameters.na
 ```
 
 It is good practice to utilize this method to improve integration with various CLI based tools. Scripts help to ensure terraform and
-kapitan can function with your CI/CD systems. It generally depends on your organizational workflows. 
+kapitan can function with your CI/CD systems. It generally depends on your organizational workflows.
 
 ### secrets
 
@@ -190,7 +191,7 @@ Although there are no particular secrets in this instance. It is possible to uti
 ### Collaboration
 
 In some situations you may find teams that are used to writing terraform in HCL. In such situations it may be difficult to adopt Kapitan into the companies workflows.
-We can however use terraform modules to simplify the integration process. This means teams which are used to writing in HCL will not need to completely adopt Jsonnet. 
+We can however use terraform modules to simplify the integration process. This means teams which are used to writing in HCL will not need to completely adopt Jsonnet.
 
 Modules can be imported into projects by defining them under the `modules` parameter key as shown in `inventory/targets/sandbox`. This means teams will only have to worry about coordinating parameter inputs for different projects.
 Jsonnet provides the ability to specify conventions and validation of input parameters. This provides peace of mind to infrastructure administrators around the tools usage.

--- a/docs/external_dependencies.md
+++ b/docs/external_dependencies.md
@@ -25,8 +25,8 @@ parameters:
 
 Use `--fetch` option to fetch the dependencies:
 
-```
-$ kapitan compile --fetch
+```shell
+kapitan compile --fetch
 ```
 
 This will download the dependencies and store them at their respective `output_path`.
@@ -34,14 +34,14 @@ By default, kapitan does not overwrite existing items with the same name as that
 
 Use the `--force` flag to force fetch (update cache with freshly fetched dependencies) and overwrite any existing item sharing the same name in the `output_path`.
 
-```
-$ kapitan compile --fetch --force
+```shell
+kapitan compile --fetch --force
 ```
 
 Use the `--cache` flag to cache the fetched items in the `.dependency_cache` directory in the root project directory.
 
-```
-$ kapitan compile --cache --fetch
+```shell
+kapitan compile --cache --fetch
 ```
 
 ## Git type
@@ -131,7 +131,7 @@ parameters:
 
 ### Example
 
-Say we want to download kapitan README.md file. Since it's on Github, we can access it as https://raw.githubusercontent.com/kapicorp/kapitan/master/README.md. Using the following inventory, we can copy this to our target folder:
+Say we want to download kapitan README.md file. Since it's on Github, we can access it as <https://raw.githubusercontent.com/kapicorp/kapitan/master/README.md>. Using the following inventory, we can copy this to our target folder:
 
 ```yaml
 parameters:
@@ -167,7 +167,6 @@ This fetches the README.md file from the URL and save it locally.
 Another use case for http types is when we want to download an archive file, such as helm packages, and extract its content.
 Setting `unpack: True` will unpack zip or tar files onto the `output_path`. In such cases, set `output_path` to a folder where you extract the content, and not the file name. You can refer to [here](compile.md#example) for the example.
 
-
 ## Helm type
 
 Fetches helm charts and any specific subcharts in the `requirements.yaml` file.
@@ -192,7 +191,6 @@ parameters:
       helm_path: <helm binary>
 ```
 
-
 ### Example
 
 If we want to download the prometheus helm chart we simply add the dependency to the monitoring target.
@@ -215,7 +213,7 @@ parameters:
         input_paths:
           - charts/prometheus
         helm_values:
-      	  alertmanager:
+         alertmanager:
             enabled: false
         helm_params:
           namespace: monitoring
@@ -250,6 +248,7 @@ $ tree -L 3
 ```
 
 If you simply want the latest chart available, either don't include the `version` key or specify an empty string.
+
 ```yaml
 parameters:
   kapitan:
@@ -267,7 +266,7 @@ parameters:
         input_paths:
           - charts/prometheus
         helm_values:
-      	  alertmanager:
+         alertmanager:
             enabled: false
         helm_params:
           namespace: monitoring

--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -21,8 +21,11 @@ Classifying almost anything will help you avoid repetition (DRY) and will force 
 For example, the snippet below, taken from the example `elasticsearch` class, declares
 what parameters are needed for the elasticsearch component:
 
+```shell
+cat inventory/classes/component/elasticsearch.yml
 ```
-$ cat inventory/classes/component/elasticsearch.yml
+
+```yaml
 parameters:
   elasticsearch:
     image: "quay.io/pires/docker-elasticsearch-kubernetes:5.5.0"
@@ -60,8 +63,11 @@ Or in the `mysql` class example, we declare the generic variables that will be s
 
 We include a secret that is referencing a GPG encrypted value in `secrets/targets/minikube-mysql/mysql/password`, or if the file doesn't exist, it will dynamically generate a random b64-encoded password, encrypt it and save it into the file.
 
+```shell
+cat inventory/classes/component/mysql.yml
 ```
-$ cat inventory/classes/component/mysql.yml
+
+```yaml
 parameters:
   mysql:
     storage: 10G
@@ -104,8 +110,11 @@ When you run `kapitan compile`, kapitan will generate `compiled` directory whose
 Inside the inventory target files you can include classes and define new values or override any values inherited from the included classes.
 For example:
 
+```shell
+cat inventory/targets/minikube-es.yml
 ```
-$ cat inventory/targets/minikube-es.yml
+
+```yaml
 classes:
   - common
   - cluster.minikube
@@ -148,7 +157,10 @@ Renders the resulting inventory values for a specific target.
 For example, rendering the inventory for the `minikube-es` target:
 
 ```shell
-$ kapitan inventory -t minikube-es
+kapitan inventory -t minikube-es
+```
+
+```yaml
 ...
 classes:
   - component.namespace
@@ -243,20 +255,20 @@ Use `kapitan lint` to checkup on your inventory or refs.
 
 Shows all inventory files where a variable is declared:
 
-```
+```shell
 $ kapitan searchvar parameters.elasticsearch.replicas
 ./inventory/targets/minikube-es.yml               2
 ./inventory/classes/component/elasticsearch.yml   1
 ```
 
-# Remote Inventory
+## Remote Inventory
 
 Kapitan is capable of recursively fetching inventory items stored in remote locations and copy it to the specified output path. This feature can be used by specifying those inventory items in classes or targets under `parameters.kapitan.inventory`. Supported types are:
 
 - [git type](#git-type)
 - [http type](#http-type)
 
-## Usage
+### Usage
 
 ```yaml
 parameters:
@@ -270,8 +282,8 @@ parameters:
 
 Use the `--fetch` flag to fetch the remote inventories and the external dependencies.
 
-```
-$ kapitan compile --fetch
+```shell
+kapitan compile --fetch
 ```
 
 This will download the dependencies and store them at their respective `output_path`.
@@ -279,19 +291,17 @@ By default, kapitan does not overwrite an existing item with the same name as th
 
 Use the `--force` flag to force fetch (update cache with freshly fetched items) and overwrite inventory items of the same name in the `output_path`.
 
-```
-$ kapitan compile --fetch --force
+```shell
+kapitan compile --fetch --force
 ```
 
 Use the `--cache` flag to cache the fetched items in the `.dependency_cache` directory in the root project directory.
 
+```shell
+kapitan compile --cache --fetch
 ```
-$ kapitan compile --cache --fetch
-```
 
-
-Class items can be specified before they are locally available as long as they are fetched in the same run. [Example](#Example) of this is given below.
-
+Class items can be specified before they are locally available as long as they are fetched in the same run. [Example](#example) of this is given below.
 
 ## Git type
 
@@ -313,6 +323,7 @@ parameters:
 ```
 
 ## http type
+
 http[s] types can fetch external inventories available at `http://` or `https://` URL.
 
 ### Usage
@@ -354,7 +365,8 @@ Root project directory before compilation:
     └── targets
         └── docker.yml
 ```
-#### Using git type to fetch the inventory item
+
+### Using git type to fetch the inventory item
 
 ```yaml
 classes:
@@ -385,6 +397,7 @@ parameters:
 ```
 
 Then run:
+
 ```shell
 $ kapitan compile --fetch
 [WARNING] Reclass class not found: 'dockerfiles'. Skipped!
@@ -397,7 +410,7 @@ Dependency https://github.com/kapicorp/kapitan: saved to templates
 Compiled docker (0.11s)
 ```
 
-#### Using http type to fetch the inventory item
+### Using http type to fetch the inventory item
 
 ```yaml
 classes:
@@ -428,6 +441,7 @@ parameters:
 ```
 
 Then run:
+
 ```shell
 $ kapitan compile --fetch
 [WARNING] Reclass class not found: 'dockerfiles'. Skipped!
@@ -444,7 +458,7 @@ Compiled docker (0.14s)
 
 Root project directory after compilation:
 
-```shell
+```text
 .
 ├── compiled
 │   └── docker
@@ -469,4 +483,3 @@ Root project directory after compilation:
 └── templates
     └── Dockerfile
 ```
-

--- a/docs/kap_proposals/kap_0_kadet.md
+++ b/docs/kap_proposals/kap_0_kadet.md
@@ -9,6 +9,7 @@ Author: @ramaro
 ## Overview
 
 ### BaseObj
+
 BaseObj implements the basic object implementation that compiles into JSON or YAML.
 Setting keys in `self.root` means they will be in the compiled output. Keys can be set as an hierarchy of attributes (courtesy of [addict](https://github.com/mewwts/addict))
 The `self.body()` method is reserved for setting self.root on instantiation:
@@ -56,10 +57,12 @@ obj = MyApp(name="myapp", foo="bar")
 ```
 
 ### Setting a skeleton
+
 Defining a large body with Python can be quite hard and repetitive to read and write.
 The `self.update_root()` method allows importing a YAML/JSON file to set the skeleton of self.root.
 
 MyApp's skeleton can be set instead like this:
+
 ```yaml
 #skel.yml
 ---
@@ -98,6 +101,7 @@ def set_replicas(self):
 ```
 
 #### Inheritance
+
 Python inheritance will work as expected:
 
 ```python
@@ -114,6 +118,7 @@ def body(self):
 
 obj = MyOtherApp(name="otherapp1", foo="bar2", size=3)
 ```
+
 compiles to:
 
 ```yaml
@@ -127,7 +132,7 @@ size: 3
 
 ## Components
 
-A component in Kadet is a python module that must implement a `main()` function returning an instance of` BaseObj`. The inventory is also available via the `inventory()` function.
+A component in Kadet is a python module that must implement a `main()` function returning an instance of`BaseObj`. The inventory is also available via the `inventory()` function.
 
 For example, a `tinyapp` component:
 
@@ -165,6 +170,7 @@ parameters:
 ```
 
 ### Common components
+
 A library in `--search-paths` (which now defaults to `.` and `lib/`) can also be a module that kadet components import. It is loaded using the `load_from_search_paths()`:
 
 ```python
@@ -175,4 +181,3 @@ def main():
   obj.root.example_app_deployment = kubelib.Deployment(name="example-app")
   return obj
 ```
-

--- a/docs/kap_proposals/kap_10_azure_key_vault.md
+++ b/docs/kap_proposals/kap_10_azure_key_vault.md
@@ -8,6 +8,7 @@ This feature will enable users to encrypt secrets using keys stored in Azure's K
 It needs to be made accessible to kapitan in one of the following ways:
 
 - As a part of target
+
 ```yaml
 parameters:
   kapitan:
@@ -17,19 +18,23 @@ parameters:
 ```
 
 - As a flag
+
 ```shell
-$ kapitan refs --key=<key_id> --write azkms:/path/to/secret -f file_with_secret_data.txt
+kapitan refs --key=<key_id> --write azkms:/path/to/secret -f file_with_secret_data.txt
 ```
 
 ## Using a key to encrypt a secret
 
 The following command will be used to encrypt a secret (using the specified key from Key Vault) and save it in the `refs-path` along with it's metadata
+
 ```shell
-$ echo "my_treasured_secret"  | kapitan refs --write azkms:path/to/secret_inside_kapitan -t <target_name> -f -
+echo "my_treasured_secret"  | kapitan refs --write azkms:path/to/secret_inside_kapitan -t <target_name> -f -
 ```
+
 The `-t <target_name>` is used to get the information about key_id.
 
 Once the secret is Base64 encoded and encrypted using the key, it will be stored in `path/to/secret_inside_kapitan` as
+
 ```yaml
 data: bXlfdHJlYXN1cmVkX3NlY3JldAo=
 encoding: original
@@ -37,11 +42,13 @@ key: https://kapitanbackend.vault.azure.net/keys/myKey/deadbeef
 type: azkms
 ```
 
-*note* Cryptographic algorithm used for encryption would be _rsa-oaep-256_. Optimal Asymmetric Encryption Padding (OAEP) is a padding scheme often used together with RSA encryption.
+*note* Cryptographic algorithm used for encryption would be *rsa-oaep-256*. Optimal Asymmetric Encryption Padding (OAEP) is a padding scheme often used together with RSA encryption.
 
 ## referencing a secret
+
 Secrets can be refered using `?{azkms:path/to/secret_id}`
 e.g.
+
 ```yaml
 parameter:
     mysql:
@@ -56,6 +63,7 @@ parameter:
 ## Revealing a secret
 
 After compilation, the secret reference will be postfixed with 8 characters from the sha256 hash of the retrieved password/secret
+
 ```yaml
 apiVersion: v1
 data:
@@ -68,12 +76,13 @@ metadata:
   namespace: minikube-mysql
 type: Opaque
 ```
+
 To reveal the secret, the following command will be used
 `$ kapitan ref --reveal -f compiled/file/containing/secret`
 
 ## Dependencies
 
-* [azure-keyvault-keys](https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/keyvault/azure-keyvault-keys)
-* [azure-identity](https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/identity/azure-identity)
+- [azure-keyvault-keys](https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/keyvault/azure-keyvault-keys)
+- [azure-identity](https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/identity/azure-identity)
 
 *note* Kapitan will not be responsible for authentication or access management to Azure

--- a/docs/kap_proposals/kap_1_external_dependencies.md
+++ b/docs/kap_proposals/kap_1_external_dependencies.md
@@ -15,7 +15,7 @@ parameters:
    - type: git | http[s]
      output_path: <output_path>
      source: <git/http[s]_url>    
-``` 
+```
 
 The output path is the path to save the dependency into. For example, it could be `/components/external/manifest.jsonnet`. Then, the user can specify the fetched file as a `kapitan.compile` item along with the locally-created files.  
 
@@ -32,7 +32,7 @@ Git type may also include `ref` and `subdir` parameters as illustrated below:
 If the file already exists at `output_path`, the fetch will be skipped. For fresh fetch of the dependencies, users may add `--fetch` option as follows:
 
 ```bash
-$ kapitan compile --fetch
+kapitan compile --fetch
 ```
 
 Users can also add the `fetch_always: true` option to the `kapitan.compile` in the inventory in order to force fresh fetch of the dependencies every time.

--- a/docs/kap_proposals/kap_2_helm_charts_input_type.md
+++ b/docs/kap_proposals/kap_2_helm_charts_input_type.md
@@ -7,7 +7,7 @@ Author: @yoshi-1224
 ## Specification
 
 This feature basically follows the `helm template` command available.  
-This will run after the fetching of the external dependencies takes place, such that users can simultaneously specify the fetch as well as the import of a helm chart dependency. 
+This will run after the fetching of the external dependencies takes place, such that users can simultaneously specify the fetch as well as the import of a helm chart dependency.
 
 ### Semantics
 
@@ -25,16 +25,15 @@ kapitan:
       
 ```
 
-This mostly maps to the options available to `helm template` command (refer to [here](https://helm.sh/docs/helm/#helm-template)). 
-
-
+This mostly maps to the options available to `helm template` command (refer to [here](https://helm.sh/docs/helm/#helm-template)).
 
 ## Implementation details
 
 C-binding between Helm (Go) and Kapitan (Python) will be created. Helm makes use of two template libraries, namely, text/template and Sprig. The code for `helm template` command will be converted into shared object (.so) using CGo, which exposes C interface that kapitan (i.e. CPython) could use.
 The source code for `helm template` command is found [here](https://github.com/helm/helm/blob/master/cmd/helm/template.go). This file will be modified to
+
 1. remove redundant options
-2. expose C-interface for Kapitan 
+2. expose C-interface for Kapitan
 
 ### Dependencies
 

--- a/docs/kap_proposals/kap_3_schema_validation.md
+++ b/docs/kap_proposals/kap_3_schema_validation.md
@@ -1,4 +1,4 @@
-# Schema Validation (for k8s) 
+# Schema Validation (for k8s)
 
 If a yaml/json output is to be used as k8s manifest, users may specify its kind and have kapitan validate its structure during `kapitan compile`.
 The plan is to have this validation feature extendable to other outputs as well, such as terraform.
@@ -22,7 +22,7 @@ parameters:
 
 ## Implementation
 
-- The schemas will be downloaded by requests from 
+- The schemas will be downloaded by requests from
 [this repository](https://raw.githubusercontent.com/garethr/kubernetes-json-schema/master/v1.6.6-standalone/deployment.json).
 - Caching of schema will also be implemented.
 

--- a/docs/kap_proposals/kap_4_standalone_executable.md
+++ b/docs/kap_proposals/kap_4_standalone_executable.md
@@ -3,6 +3,7 @@
 Create a portable (i.e. static) kapitan binary for users. This executable will be made available for each release on Github. The target/tested platform is Debian 9 (possibly Windows to be supported in the future).
 
 Criteria:
+
 - speed of the resulting binary
 - size of the resulting binary
 - portability of the binary (single-file executable or has an accompanying folder)
@@ -12,7 +13,7 @@ Criteria:
 
 Author: @yoshi-1224
 
-### Tools to be explored
+## Tools to be explored
 
-- (tentative first-choice) [Pyinstaller](https://github.com/pyinstaller/pyinstaller) 
-- (Alternative) [nuitka](https://github.com/Nuitka/Nuitka) (also part of GSoC 2019. It might soon support [single-file executable output](https://github.com/Nuitka/Nuitka/issues/230)). 
+- (tentative first-choice) [Pyinstaller](https://github.com/pyinstaller/pyinstaller)
+- (Alternative) [nuitka](https://github.com/Nuitka/Nuitka) (also part of GSoC 2019. It might soon support [single-file executable output](https://github.com/Nuitka/Nuitka/issues/230)).

--- a/docs/kap_proposals/kap_5_ref_types_redesign.md
+++ b/docs/kap_proposals/kap_5_ref_types_redesign.md
@@ -32,13 +32,12 @@ A new `plain` backend type is introduced and will compile into revealed state in
 
 A new `base64` backend type will store a base64 encoded value as the backend suggests (replacing the old badly named `ref` backend).
 
-
 The command line for secrets will be instead:
 
 ```shell
-$ kapitan refs --write gpg:my/secret1 ...
-$ kapitan refs --write base64:my/file ...
-$ kapitan refs --write plain:my/info ...
+kapitan refs --write gpg:my/secret1 ...
+kapitan refs --write base64:my/file ...
+kapitan refs --write plain:my/info ...
 ```
 
 ### plain backend
@@ -48,13 +47,13 @@ The `plain` backend type will allow referring to external state by updating refs
 For example, one can update the value of an environment variable and use `?{plain:my/user}` as a reference in a template:
 
 ```shell
-$ echo $USER | kapitan refs --write plain:my/user -f -
+echo $USER | kapitan refs --write plain:my/user -f -
 ```
 
 Or update a docker image value as ref `?{plain:images/dev/envoy}`:
 
 ```shell
-$ echo 'envoyproxy/envoy:v1.10.0' | kapitan refs --write plain:images/dev/envoy -f -
+echo 'envoyproxy/envoy:v1.10.0' | kapitan refs --write plain:images/dev/envoy -f -
 ```
 
 These references will be compiled into their values instead of hashed tags.
@@ -68,7 +67,6 @@ Except that this time, the name is representative of what is actually happening 
 
 Refs will be stored by default in the `./refs` path set by `--refs-path` replacing the `--secrets-path` flag.
 
-
 ## Background
 
 ### Kapitan Secrets
@@ -79,10 +77,10 @@ On compile, secret tags are updated into hashed tags which validate and instruct
 
 ### Kapitan Secrets example
 
-The following command creates a GPG encrypted secret with the contents of _file.txt_ for recipient `ramaro@google.com` to read:
+The following command creates a GPG encrypted secret with the contents of *file.txt* for recipient `ramaro@google.com` to read:
 
 ```shell
-$ kapitan secrets --write gpg:my/secret1 -f file.txt --recipients ramaro@google.com
+kapitan secrets --write gpg:my/secret1 -f file.txt --recipients ramaro@google.com
 ```
 
 This secret can be referred to in a jsonnet compoment:

--- a/docs/kap_proposals/kap_6_hashicorp_vault.md
+++ b/docs/kap_proposals/kap_6_hashicorp_vault.md
@@ -3,9 +3,11 @@
 This feature allows the user to fetch secrets from [Hashicorp Vault](https://www.vaultproject.io/), with the new secret backend keyword 'vaultkv'.
 
 Author: [@vaibahvk](https://github.com/vaibhavk) [@daminisatya](https://github.com/daminisatya)
+
 ## Specification
 
 The following variables need to be exported to the environment(depending on authentication used) where you will run `kapitan refs --reveal` in order to authenticate to your HashiCorp Vault instance:
+
 * VAULT_ADDR: URL for vault
 * VAULT_SKIP_VERIFY=true: if set, do not verify presented TLS certificate before communicating with Vault server. Setting this variable is not recommended except during testing
 * VAULT_TOKEN: token for vault or file (~/.vault-tokens)
@@ -22,13 +24,16 @@ The following variables need to be exported to the environment(depending on auth
 Considering a key-value pair like `my_key`:`my_secret` ( in our case let’s store `hello`:`batman` inside the vault ) in the path `secret/foo` in a kv-v2(KV version 2) secret engine on the vault server, to use this as a secret either follow:
 
 ```shell
-$ echo "foo:hello" > somefile.txt
-$ kapitan refs --write vaultkv:path/to/secret_inside_kapitan --file somefile.txt --target dev-sea
+echo "foo:hello" > somefile.txt
+kapitan refs --write vaultkv:path/to/secret_inside_kapitan --file somefile.txt --target dev-sea
 ```
+
 or in a single line
+
 ```shell
-$ echo "foo:hello"  | kapitan refs --write vaultkv:path/to/secret_inside_kapitan -t dev-sea -f -
+echo "foo:hello"  | kapitan refs --write vaultkv:path/to/secret_inside_kapitan -t dev-sea -f -
 ```
+
 The entire string __"foo:hello"__ is base64 encoded and stored in the secret_inside_kapitan. Now secret_inside_kapitan contains the following
 
 ```yaml
@@ -41,6 +46,7 @@ vault_params:
 
 Encoding tells the type of data given to kapitan, if it is `original` then after decoding base64 we'll get the original secret and if it is `base64` then after decoding once we still have a base64 encoded secret and have to decode again.
 Parameters in the secret file are collected from the inventory of the target we gave from CLI `--target dev-sea`. If target isn't provided then kapitan will identify the variables from the environment, but providing `auth` is necessary as a key inside target parameters like the one shown:
+
 ```yaml
 parameters:
   kapitan:
@@ -55,12 +61,14 @@ parameters:
         VAULT_CLIENT_KEY: /path/to/key
         VAULT_CLIENT_CERT: /path/to/cert
 ```
+
 Environment variables that can be defined in kapitan inventory are `VAULT_ADDR`, `VAULT_NAMESPACE`, `VAULT_SKIP_VERIFY`, `VAULT_CLIENT_CERT`, `VAULT_CLIENT_KEY`, `VAULT_CAPATH` & `VAULT_CACERT`.
 Extra parameters that can be defined in inventory are:
+
 * `auth`: specify which authentication method to use like `token`,`userpass`,`ldap`,`github` & `approle`
 * `mount`: specify the mount point of key's path. e.g if path=`alpha-secret/foo/bar` then `mount: alpha-secret` (default `secret`)
 * `engine`: secret engine used, either `kv-v2` or `kv` (default `kv-v2`)
-Environment variables cannot be defined in inventory are `VAULT_TOKEN`,`VAULT_USERNAME`,`VAULT_PASSWORD`,`VAULT_ROLE_ID`,` VAULT_SECRET_ID`.
+Environment variables cannot be defined in inventory are `VAULT_TOKEN`,`VAULT_USERNAME`,`VAULT_PASSWORD`,`VAULT_ROLE_ID`,`VAULT_SECRET_ID`.
 This makes the secret_inside_kapitan file accessible throughout the inventory, where we can use the secret whenever necessary like `?{vaultkv:path/to/secret_inside_kapitan}`
 
 Following is the example file having a secret and pointing to the vault `?{vaultkv:path/to/secret_inside_kapitan}`
@@ -77,7 +85,9 @@ parameters:
       - --verbose=${verbose}
       - --password=?{vaultkv:path/to/secret_inside_kapitan}
 ```
+
 when `?{vaultkv:path/to/secret_inside_kapitan}` is compiled, it will look same with an 8 character prefix of sha256 hash added at the end like:
+
 ```yaml
 kind: Deployment
 metadata:
@@ -101,7 +111,7 @@ spec:
 Only the user with the required tokens/permissions can reveal the secrets. Please note that the roles and permissions will be handled at the Vault level. We need not worry about it within Kapitan. Use the following command to reveal the secrets:
 
 ```shell
-$ kapitan refs --reveal -f compile/file/containing/secret
+kapitan refs --reveal -f compile/file/containing/secret
 ```
 
 Following is the result of the cod-deployment.md file after Kapitan reveal.
@@ -128,4 +138,4 @@ spec:
 
 ## Dependencies
 
-- [hvac](https://github.com/hvac/hvac) is a python client for Hashicorp Vault
+* [hvac](https://github.com/hvac/hvac) is a python client for Hashicorp Vault

--- a/docs/kap_proposals/kap_7_remote_inventory.md
+++ b/docs/kap_proposals/kap_7_remote_inventory.md
@@ -19,16 +19,17 @@ parameters:
      output_path: <relative_output_path>
 ```
 
-On executing the ``` $ kapitan compile --fetch``` command, first the remote inventories will be fetched followed by fetching of external dependencies and finally merge the inventory to compile.
-
+On executing the ```$ kapitan compile --fetch``` command, first the remote inventories will be fetched followed by fetching of external dependencies and finally merge the inventory to compile.
 
 ## Copying inventory files to the output location
+
 The output path is the path to save the inventory items into. The path is relative to the `inventory/` directory. For example, it could be `/classes/`. The contents of the fetched inventory will be recursively copied.
 
 The fetched inventory files will be cached in the `.dependency_cache` directory if `--cache` is set.
 eg. `$ kapitan compile --fetch --cache`
 
 ## Force fetching
+
 While fetching, the output path will be recursively checked to see if it contains any file with the same name. If so, kapitan will skip fetching it.
 
 To overwrite the files with the newly downloaded inventory items, we can add the `--force` flag to the compile command, as shown below.
@@ -36,6 +37,7 @@ To overwrite the files with the newly downloaded inventory items, we can add the
 `$ kapitan compile --fetch --force`
 
 ## URL type
+
 The URL type can be either git or http(s). Depending on the URL type, the configuration file may have additional arguments.
 
 E.g Git type may also include aditional `ref` parameter as illustrated below:
@@ -49,6 +51,7 @@ inventory:
 ```
 
 ## Implementation details
+
 TODO
 
 ### Dependencies

--- a/docs/kap_proposals/kap_8_google_secret_management.md
+++ b/docs/kap_proposals/kap_8_google_secret_management.md
@@ -7,6 +7,7 @@ This feature will enable users to retrieve secrets from Google Secret Manager AP
 `project_id` uniquely identifies GCP projects, and it needs to be made accessible to kapitan in one of the following ways:
 
 - As a part of target
+
 ```yaml
 parameters:
   kapitan:
@@ -16,26 +17,32 @@ parameters:
 ```
 
 - As a flag
+
 ```shell
-$ kapitan refs --google-project-id=<Project_Id> --write gsm:/path/to/secret_id -f secret_id_file.txt
+kapitan refs --google-project-id=<Project_Id> --write gsm:/path/to/secret_id -f secret_id_file.txt
 ```
 
 - As an environment variable
+
 ```shell
 export PROJECT_ID=<Project_Id>
 ```
 
 ## Using a secret
+
 In GCP, a secret contains one or more secret versions, along with its metadata. The actual contents of a secret are stored in a secret version. Each secret is identified by a name. We call that variable `secret_id` e.g. _my\_treasured\_secret_.
 The URI of the secret becomes `projects/<Project_Id>/secrets/my_treasured_secret`
 
 The following command will be used to add a `secret_id` to kapitan.
+
 ```shell
-$ echo "my_treasured_secret"  | kapitan refs --write gsm:path/to/secret_inside_kapitan -t <target_name> -f -
+echo "my_treasured_secret"  | kapitan refs --write gsm:path/to/secret_inside_kapitan -t <target_name> -f -
 ```
+
 The `-t <target_name>` is used to get the information about Project_ID.
 
 The `secret_id` is Base64 encoded and stored in `path/to/secret_inside_kapitan` as
+
 ```yaml
 data: bXlfdHJlYXN1cmVkX3NlY3JldAo=
 encoding: original
@@ -45,8 +52,10 @@ gsm_params:
 ```
 
 ## referencing a secret
+
 Secrets can be refered using `?{gsm:path/to/secret_id:version_id}`
 e.g.
+
 ```yaml
 parameter:
     mysql:
@@ -57,11 +66,13 @@ parameter:
             root:
                 password: ?{gsm:path/to/secret_id:version_id}
 ```
+
 Here, `version_id` will be an optional argument. By default it will point to `latest`.
 
 ## Revealing a secret
 
 After compilation, the secret reference will be postfixed with 8 characters from the sha256 hash of the retrieved password
+
 ```yaml
 apiVersion: v1
 data:
@@ -74,11 +85,12 @@ metadata:
   namespace: minikube-mysql
 type: Opaque
 ```
+
 To reveal the secret, the following command will be used
 `$ kapitan ref --reveal -f compiled/file/containing/secret`
 
 ## Dependencies
 
-* [google-cloud-secret-manager](https://github.com/googleapis/python-secret-manager)
+- [google-cloud-secret-manager](https://github.com/googleapis/python-secret-manager)
 
-*note* Kapitan will not be responsible for authentication or access management to GCP
+_note_ Kapitan will not be responsible for authentication or access management to GCP

--- a/docs/kap_proposals/kap_8_modularize_kapitan.md
+++ b/docs/kap_proposals/kap_8_modularize_kapitan.md
@@ -3,9 +3,10 @@
 Kapitan is packaged in PYPI and as a binary along with all its dependencies. Adding an extra key/security backend means that we need to ship another dependency with that PYPI package, making deploying changes more complicated. This project would modularize kapitan into core dependencies and extra modules.
 
 ## Usage
+
 ```sh
-$ pip3 install --user kapitan # to install only core dependencies
-$ Pip3 install --user kapitan[gkms] ​# gkms is the module
+pip3 install --user kapitan # to install only core dependencies
+Pip3 install --user kapitan[gkms] ​# gkms is the module
 ```
 
 ## Implementation

--- a/docs/kap_proposals/kap_9_bring_your_own_helm.md
+++ b/docs/kap_proposals/kap_9_bring_your_own_helm.md
@@ -3,11 +3,12 @@
 ## The Problem
 
 Currently the helm binding can't be run on Mac OSX. Attempts to fix this have been made on several occasions:
-- https://github.com/kapicorp/kapitan/pull/414
-- https://github.com/kapicorp/kapitan/pull/547
-- https://github.com/kapicorp/kapitan/pull/568
 
-There are some issues with the current bindings besides the lack of Mac OSX support. The golang runtime (1.14) selected will effect older versions helm templates: https://github.com/helm/helm/issues/7711. Users can't select the version of helm they'd like to use for templating.
+- <https://github.com/kapicorp/kapitan/pull/414>
+- <https://github.com/kapicorp/kapitan/pull/547>
+- <https://github.com/kapicorp/kapitan/pull/568>
+
+There are some issues with the current bindings besides the lack of Mac OSX support. The golang runtime (1.14) selected will effect older versions helm templates: <https://github.com/helm/helm/issues/7711>. Users can't select the version of helm they'd like to use for templating.
 
 ## Solution
 

--- a/docs/kapitan_overview.md
+++ b/docs/kapitan_overview.md
@@ -1,24 +1,26 @@
-### Main concepts
+# Kapitan Overview
+
+## Main concepts
 
 ![kapitan_overview](images/kapitan_overview.png)
 
-#### Inventory
+## Inventory
 
 Inventory is a hierarchical database of variables, defined in yaml files, that are passed to the targets during compilation. This will be explained in detail in the [inventory](inventory.md) section of the documentation.
 
-#### Components (templates)
+## Components (templates)
 
 Components will receive the inventory values for each individual target and gets rendered and saved into the `compiled` directory. The types of available templates and how to use them is discussed in the [compile operation](compile.md) section of the documentation.
 
-### Typical Folder Structure
+## Typical Folder Structure
 
-#### kapitan init
+### kapitan init
 
 To start off a kapitan project, you can run `kapitan init --directory <directory>` to populate a new directory with the recommended kapitan folder structure.
 
 The bare minimum structure that makes use of kapitan features may look as follows:
 
-```
+```text
 .
 ├── components
 │   ├── mycomponent.jsonnet
@@ -45,11 +47,11 @@ The bare minimum structure that makes use of kapitan features may look as follow
 - `inventory/classes`: stores inventory values to be inherited by targets
 - `refs`: stores secrets referenced inside the inventory
 
-#### Example: kubernetes deployment
+### Example: kubernetes deployment
 
 Refer to the structure below for more production-like uses of kapitan for kubernetes deployment:
 
-```
+```text
 .
 ├── components
 │   ├── elasticsearch
@@ -91,4 +93,3 @@ Refer to the structure below for more production-like uses of kapitan for kubern
 ```
 
 The use of each file in this folder will become clear in the the subsequent documentations.
-

--- a/docs/proposals.md
+++ b/docs/proposals.md
@@ -8,11 +8,11 @@ for new features.
 
 ## Existing proposals
 
-[Kadet input type](kap_proposals/kap_0_kadet.md) 
+[Kadet input type](kap_proposals/kap_0_kadet.md)
 
 [External dependency management](kap_proposals/kap_1_external_dependencies.md)
 
-[Helm charts input type](kap_proposals/kap_2_helm_charts_input_type.md) 
+[Helm charts input type](kap_proposals/kap_2_helm_charts_input_type.md)
 
 [Kubernetes scheme validation](kap_proposals/kap_3_schema_validation.md)
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -16,7 +16,7 @@ If you want to get started with secrets but don't have a GPG or KMS setup, you c
 
 The usual flow of creating and using an encrypted secret with kapitan is:
 
-#### 1. Define your GPG recipients, Vault client parameters or KMS key
+### 1. Define your GPG recipients, Vault client parameters or KMS key
 
 This is done in the inventory under `parameters.kapitan.secrets`.
 
@@ -51,15 +51,15 @@ parameters:
         key: 2022-02-13-test
 ```
 
-#### 2. Create Your Secret
+### 2. Create Your Secret
 
-##### Manually via command line:
+#### Manually via command line
 
 ```shell
-$ kapitan refs --write <secret_type>:path/to/secret/file -t <target_name> -f <secret_file>
+kapitan refs --write <secret_type>:path/to/secret/file -t <target_name> -f <secret_file>
 ```
 
-​	where `<secret_type>` can be any of:
+​ where `<secret_type>` can be any of:
 
 - `base64`: base64 (not encrypted!)
 - `gpg`: GPG
@@ -71,7 +71,7 @@ $ kapitan refs --write <secret_type>:path/to/secret/file -t <target_name> -f <se
 
 Kapitan will inherit the secrets configuration for the specified target, and encrypt and save your secret into `<path/to/secret/file>`.
 
-##### Automatically
+#### Automatically
 
 When referencing your secret in the inventory during compile, you can use the following functions to automatically generate, encrypt and save your secret:
 
@@ -91,7 +91,7 @@ When referencing your secret in the inventory during compile, you can use the fo
 
 *Note*: `vaultkv` can't be used to generate secrets automatically for now, manually create the secret using the command line.
 
-#### 3. Reference your secrets in your classes/targets and run `kapitan compile`
+### 3. Reference your secrets in your classes/targets and run `kapitan compile`
 
 Secrets can be referenced in the format `?{<secret_type>:path/to/secret/file}`.
 
@@ -106,12 +106,12 @@ users:
 
 During compile, kapitan will search for the path `targets/${target_name}/mysql/password`. Should it not exist, then it will automatically generate a random base64 password and save it to that path.
 
-#### 4. Reveal and use the secrets
+### 4. Reveal and use the secrets
 
 You can reveal the secrets referenced in the outputs of `kapitan compile` via:
 
-```
-$ kapitan refs --reveal -f path/to/rendered/template
+```shell
+kapitan refs --reveal -f path/to/rendered/template
 ```
 
 For example, `compiled/minikube-mysql/manifests/mysql_secret.yml` with the following content:
@@ -133,39 +133,39 @@ type: Opaque
 
 can be revealed as follows:
 
-```
-$ kapitan refs --reveal -f compiled/minikube-mysql/manifests/mysql_secret.yml
+```shell
+kapitan refs --reveal -f compiled/minikube-mysql/manifests/mysql_secret.yml
 ```
 
 This will substitute the referenced secrets with the actual decrypted secrets stored at the referenced paths and display the file content.
 
 You can also use:
 
-```
-$ kapitan refs --reveal --ref-file refs/targets/all-glob/mysql/password
+```shell
+kapitan refs --reveal --ref-file refs/targets/all-glob/mysql/password
 ```
 
 or
 
-```
-$ kapitan refs --reveal --tag "?{base64:targets/all-glob/mysql/password}"
-$ # or
-$ kapitan refs --reveal --tag "?{base64:targets/all-glob/mysql/password:3192c15c}"
+```shell
+kapitan refs --reveal --tag "?{base64:targets/all-glob/mysql/password}"
+# or
+kapitan refs --reveal --tag "?{base64:targets/all-glob/mysql/password:3192c15c}"
 ```
 
 for more convenience.
 
-#### 5. Compile refs in embedded format
+### 5. Compile refs in embedded format
 
 This allows revealing compiled files without needing access to ref files by using:
 
-```
-$ kapitan compile --embed-refs
+```shell
+kapitan compile --embed-refs
 ```
 
 Compiled files containing refs will now have the references embedded in the compiled file under the following format (gkms backend used as an example):
 
-```
+```yaml
 ?{gkms:ReallyLongBase64HereZ2FyZ2FiZQo=:embedded}
 ```
 
@@ -185,8 +185,8 @@ mysql_passwords:
 
 This can be manually encrypted by:
 
-```
-$ kapitan refs --write gpg:components/secrets/mysql_secrets -t prod -f secrets/mysql_secrets
+```shell
+kapitan refs --write gpg:components/secrets/mysql_secrets -t prod -f secrets/mysql_secrets
 ```
 
 To reference `secret_foo`inside this file, you can specify it in the inventory as follows:
@@ -201,7 +201,7 @@ to locate a value for a reference from the environment using a prefixed variable
 and use this value with the refs command.
 
 ```shell
-$ echo "my_default_value" | kapitan refs --write env:path/to/secret_inside_kapitan -t <target_name> -f -
+echo "my_default_value" | kapitan refs --write env:path/to/secret_inside_kapitan -t <target_name> -f -
 ```
 
 When this reference is created and then referred to in the parameters, it will use the last path component, from a
@@ -218,26 +218,26 @@ parameters:
 When using the above parameters reference, values would be consulted in the environment from the following
 variables:
 
-* `$KAPITAN_VAR_mysql_secret_foo`
-* `$KAPITAN_VAR_mysql_secret_bar`
-
+- `$KAPITAN_VAR_mysql_secret_foo`
+- `$KAPITAN_VAR_mysql_secret_bar`
 
 ### Vaultkv Secret Backend (Read Only) - Addons
 
 Considering a key-value pair like `my_key`:`my_secret` in the path `secret/foo/bar` in a kv-v2(KV version 2) secret engine on the vault server, to use this as a secret use:
 
 ```shell
-$ echo "foo/bar:my_key"  | kapitan refs --write vaultkv:path/to/secret_inside_kapitan -t <target_name> -f -
+echo "foo/bar:my_key"  | kapitan refs --write vaultkv:path/to/secret_inside_kapitan -t <target_name> -f -
 ```
 
 Parameters in the secret file are collected from the inventory of the target we gave from CLI `-t <target_name>`. If target isn't provided then kapitan will identify the variables from the environment when revealing secret.
 
 Environment variables that can be defined in kapitan inventory are `VAULT_ADDR`, `VAULT_NAMESPACE`, `VAULT_SKIP_VERIFY`, `VAULT_CLIENT_CERT`, `VAULT_CLIENT_KEY`, `VAULT_CAPATH` & `VAULT_CACERT`.
 Extra parameters that can be defined in inventory are:
-* `auth`: specify which authentication method to use like `token`,`userpass`,`ldap`,`github` & `approle`
-* `mount`: specify the mount point of key's path. e.g if path=`alpha-secret/foo/bar` then `mount: alpha-secret` (default `secret`)
-* `engine`: secret engine used, either `kv-v2` or `kv` (default `kv-v2`)
-Environment variables cannot be defined in inventory are `VAULT_TOKEN`,`VAULT_USERNAME`,`VAULT_PASSWORD`,`VAULT_ROLE_ID`,` VAULT_SECRET_ID`.
+
+- `auth`: specify which authentication method to use like `token`,`userpass`,`ldap`,`github` & `approle`
+- `mount`: specify the mount point of key's path. e.g if path=`alpha-secret/foo/bar` then `mount: alpha-secret` (default `secret`)
+- `engine`: secret engine used, either `kv-v2` or `kv` (default `kv-v2`)
+Environment variables cannot be defined in inventory are `VAULT_TOKEN`,`VAULT_USERNAME`,`VAULT_PASSWORD`,`VAULT_ROLE_ID`,`VAULT_SECRET_ID`.
 
 ```yaml
 parameters:
@@ -259,18 +259,19 @@ parameters:
 Considering a key-value pair like `my_key`:`my_secret` in the path `secret/foo/bar` in a transit secret engine on the vault server, to use this as a secret use:
 
 ```shell
-$ echo "any.value:whatever-you_may*like"  | kapitan refs --write vaulttransit:my_target/to/secret_inside_kapitan -t <target_name> -f -
+echo "any.value:whatever-you_may*like"  | kapitan refs --write vaulttransit:my_target/to/secret_inside_kapitan -t <target_name> -f -
 ```
 
 Parameters in the secret file are collected from the inventory of the target we gave from CLI `-t <target_name>`. If target isn't provided then kapitan will identify the variables from the environment when revealing secret.
 
 Environment variables that can be defined in kapitan inventory are `VAULT_ADDR`, `VAULT_NAMESPACE`, `VAULT_SKIP_VERIFY`, `VAULT_CLIENT_CERT`, `VAULT_CLIENT_KEY`, `VAULT_CAPATH` & `VAULT_CACERT`.
 Extra parameters that can be defined in inventory are:
-* `auth`: specify which authentication method to use like `token`,`userpass`,`ldap`,`github` & `approle`
-* `mount`: specify the mount point of key's path. e.g if path=`my_mount` (default `transit`)
-* `crypto_key`: Name of the `encryption key` defined in vault
-* `always_latest`: Always rewrap ciphertext to latest rotated crypto_key version
-Environment variables cannot be defined in inventory are `VAULT_TOKEN`,`VAULT_USERNAME`,`VAULT_PASSWORD`,`VAULT_ROLE_ID`,` VAULT_SECRET_ID`.
+
+- `auth`: specify which authentication method to use like `token`,`userpass`,`ldap`,`github` & `approle`
+- `mount`: specify the mount point of key's path. e.g if path=`my_mount` (default `transit`)
+- `crypto_key`: Name of the `encryption key` defined in vault
+- `always_latest`: Always rewrap ciphertext to latest rotated crypto_key version
+Environment variables cannot be defined in inventory are `VAULT_TOKEN`,`VAULT_USERNAME`,`VAULT_PASSWORD`,`VAULT_ROLE_ID`,`VAULT_SECRET_ID`.
 
 ```yaml
 parameters:
@@ -309,6 +310,7 @@ It should be of the form `https://{keyvault-name}.vault.azure.net/{object-type}/
 #### Defining the KMS key
 
 This is done in the inventory under `parameters.kapitan.secrets`.
+
 ```yaml
 parameters:
   kapitan:
@@ -319,28 +321,33 @@ parameters:
       azkms:
         key: 'https://<keyvault-name>.vault.azure.net/keys/<object-name>/<object-version>'
 ```
+
 The key can also be specified using the `--key` flag
 
 #### Creating a secret
 
-Secrets can be created using any of the methods described in the ["creating your secret"](##2.-Create-Your-Secret) section.
+Secrets can be created using any of the methods described in the ["creating your secret"](#2-create-your-secret) section.
 
 For example, if the key is defined in the `prod` target file
+
 ```shell
-$ echo "my_encrypted_secret" | kapitan refs --write azkms:path/to/secret_inside_kapitan -t prod -f -
+echo "my_encrypted_secret" | kapitan refs --write azkms:path/to/secret_inside_kapitan -t prod -f -
 ```
+
 Using the `--key` flag and a `key_id`
+
 ```shell
-$ echo "my_encrypted_secret" | kapitan refs --write azkms:path/to/secret_inside_kapitan --key=<key_id> -f -
+echo "my_encrypted_secret" | kapitan refs --write azkms:path/to/secret_inside_kapitan --key=<key_id> -f -
 ```
+
 #### Referencing and revealing a secret
-Secrets can be [referenced](####3.-Reference-your-secrets-in-your-classes/targets-and-run-`kapitan-compile`) and [revealed](####4.-Reveal-and-use-the-secrets) in any of the ways described above.
+
+Secrets can be [referenced](#3-reference-your-secrets-in-your-classestargets-and-run-kapitan-compile) and [revealed](#4-reveal-and-use-the-secrets) in any of the ways described above.
 
 For example, to reveal the secret stored at `path/to/secret_inside_kapitan`
+
 ```shell
-$ kapitan refs --reveal --tag "?{azkms:path/to/secret_inside_kapitan}"
+kapitan refs --reveal --tag "?{azkms:path/to/secret_inside_kapitan}"
 ```
 
-
-*Note:* Cryptographic algorithm used for encryption is _rsa-oaep-256_.
-
+*Note:* Cryptographic algorithm used for encryption is *rsa-oaep-256*.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,7 +2,7 @@
 
 To see all the available commands, run:
 
-```
+```shell
 $ kapitan -h
 usage: kapitan [-h] [--version]
                {eval,compile,inventory,searchvar,secrets,lint} ...
@@ -32,7 +32,7 @@ optional arguments:
 
 Additional parameters are available for each positional argument. For example:
 
-```
+```shell
 $ kapitan compile -h
 usage: kapitan compile [-h] [--search-paths JPATH [JPATH ...]]
                        [--jinja2-filters FPATH] [--verbose] [--prune]
@@ -93,17 +93,17 @@ optional arguments:
 
 If you only want to compile a subset or specific targets, you can use the two kapitan compile flags `--targets, -t` or `--labels, -l`.
 
-#### Specific target(s)
+### Specific target(s)
 
-```
+```shell
 $ cd examples/kubernetes
 $ kapitan compile -t minikube-mysql
 Compiled minikube-mysql (0.43s)
 ```
 
-#### Using labels
+### Using labels
 
-```
+```shell
 $ cd examples/kubernetes
 
 $ cat inventory/classes/component/nginx-kadet.yml  # Inherited by minikube-nginx-kadet target
@@ -122,24 +122,23 @@ Compiled minikube-nginx-kadet (0.14s)
 
 These parameters can also be defined in a local `.kapitan` file per project directory, for example:
 
-
 To enforce the kapitan version used for compilation (for consistency and safety), you can add `version` to `.kapitan`:
 
-```
+```shell
 $ cat .kapitan
 version: 0.21.0
 ```
 
 Or to skip all minor version checks:
 
-```
+```shell
 $ cat .kapitan
 version: 0.21
 ```
 
 You can also permanently define all command line flags in the `.kapitan` config file. For example:
 
-```
+```shell
 $ cat .kapitan
 version: 0.21
 
@@ -150,13 +149,13 @@ compile:
 
 would be equivalent to running:
 
-```
+```shell
 kapitan compile --indent 4 --parallelism 8
 ```
 
 or
 
-```
+```shell
 $ cat .kapitan
 version: 0.21
 
@@ -166,6 +165,6 @@ inventory:
 
 which would be equivalent to always running:
 
-```
+```shell
 kapitan inventory --inventory-path=./some_path
 ```

--- a/docs/validate.md
+++ b/docs/validate.md
@@ -2,20 +2,24 @@
 
 Validates the schema of compiled output. Validate options are specified in the inventory under `parameters.kapitan.validate`. Supported types are:
 
-- [kubernetes manifests](#kubernetes-manifests)
+- [kapitan validate](#kapitan-validate)
+  - [Usage](#usage)
+  - [Kubernetes manifests](#kubernetes-manifests)
+    - [Overview](#overview)
+    - [Example](#example)
 
 ## Usage
 
 1. Manually via command line after compile:
 
-   ```
-   $ kapitan validate
+   ```shell
+   kapitan validate
    ```
 
 2. Automatically, together with compile:
 
-   ```
-   $ kapitan compile --validate
+   ```shell
+   kapitan compile --validate
    ```
 
 ## Kubernetes manifests
@@ -30,7 +34,7 @@ Kubernetes resources are identified by their `kind`. For example, they are:
 
 The manifest for each kind has certain restrictions such as required properties. Using kapitan, you can validate against the schemas to confirm that your compiled output indeed is a valid kubernetes manifest.
 
-First time they are used, the schemas for kubernetes manifests are dynamically downloaded from https://kubernetesjsonschema.dev. Those schemas will be cached into `./schemas/` by default, which can be modified using `--schemas-path` option. However, it is recommended to use `.kapitan` configuration as follows to avoid the need of typing down this option for every command: 
+First time they are used, the schemas for kubernetes manifests are dynamically downloaded from <https://kubernetesjsonschema.dev>. Those schemas will be cached into `./schemas/` by default, which can be modified using `--schemas-path` option. However, it is recommended to use `.kapitan` configuration as follows to avoid the need of typing down this option for every command:
 
 ```shell
 $ cat .kapitan
@@ -41,7 +45,7 @@ validate:
 
 ### Example
 
-Refer to the `minikube-es` inventory in [kapitan inventory](#kapitan-inventory). To validate the schema of the compiled StatefulSet manifest at `compiled/minikube-es/manifests/es-client.yml` (created by `components/elasticsearch/main.jsonnet`), add `kapitan.validate` parameters in `minikube-es` inventory:
+Refer to the `minikube-es` inventory in [kapitan inventory](inventory.md). To validate the schema of the compiled StatefulSet manifest at `compiled/minikube-es/manifests/es-client.yml` (created by `components/elasticsearch/main.jsonnet`), add `kapitan.validate` parameters in `minikube-es` inventory:
 
 ```yaml
 kapitan:
@@ -65,7 +69,7 @@ kapitan:
 
 Then run:
 
-```
+```shell
 $ kapitan validate -t minikube-es
 
 invalid 'statefulset' manifest at ./compiled/minikube-es/manifests/es-client.yml


### PR DESCRIPTION
Fixes issue #867 

## Proposed Changes
  - Added markdown linter from [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli) to pre-commit
  - Added `.markdownlintignore` file : specifies which directories/ files get ignored
  - Added `.markdownlint.yml` file : configuration for markdown linter
  - Applied markdown rules automatically (`markdownlint-fix`) and manually
 
### Explanation of non-default rules in `markdownlint.yml`
- `MD013` sets the maximum line length by default to 80 characters. In the docs are some lines containing up to 550 characters, so I set the maximum to 600 characters. Fixing these long lines down to 80 characters, will be a change for the future.
- `MD024` won't allow the same header name in one file. Thus we have several headers like `Usage`, `Breaking`, `Updates`, `Examples` and so on, I deactivated the rule.
- `MD033` won't allow `html`-tags in the markdown files. To allow the `img` tag in `README.md`, we have to add it to the parameter `allowed_elements`.
