### PR TITLE
Add basic auth generator function

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -84,6 +84,7 @@ When referencing your secret in the inventory during compile, you can use the fo
 - `publickey` - Derives the public key from a revealed private key i.e. `||reveal:path/to/encrypted_private_key|publickey`
 - `rsapublic` - Derives an RSA public key from a revealed private key i.e. `||reveal:path/to/encrypted_private_key|rsapublic` (deprecated, use `publickey` instead)
 - `loweralphanum` - Generates a DNS-compliant text string (a-z and 0-9), containing lower alphanum chars `||`
+- `basicauth` - Generates a base64 encoded pair of `username:password`, i.e. `||basicauth:username:password`
 
 *Note*: The first operator here `||` is more similar to a logical OR. If the secret file doesn't exist, kapitan will generate it and apply the functions after the `||`. If the secret file already exists, no functions will run.
 

--- a/kapitan/refs/functions.py
+++ b/kapitan/refs/functions.py
@@ -30,6 +30,7 @@ def eval_func(func_name, ctx, *func_params):
         "publickey": public_key,
         "reveal": reveal,
         "loweralphanum": loweralphanum,
+        "basicauth": basicauth,
     }
 
     return func_lookup[func_name](ctx, *func_params)
@@ -154,3 +155,23 @@ def loweralphanum(ctx, chars="8"):
     except ValueError:
         raise RefError(f"Ref error: eval_func: {chars} cannot be converted into integer.")
     ctx.data = "".join(secrets.choice(pool) for i in range(chars))
+
+
+def basicauth(ctx, username="", password=""):
+    # check if parameters are specified
+    if not username:
+        # use random pet name as username
+        username = "".join(secrets.choice(string.ascii_lowercase) for i in range(8))
+
+    if not password:
+        # generate random password
+        pool = string.ascii_letters + string.digits
+        password = "".join(secrets.choice(pool) for i in range(8))
+    # generate basic-auth token (base64-encoded)
+    token = username + ":" + password
+    token_bytes = token.encode()
+    token_bytes_b64 = base64.b64encode(token_bytes)
+    token_b64 = token_bytes_b64.decode()
+
+    # set generated token to ctx.data
+    ctx.data = token_b64

--- a/kapitan/refs/functions.py
+++ b/kapitan/refs/functions.py
@@ -156,15 +156,7 @@ def loweralphanum(ctx, nchars="8"):
 def random(ctx, type="str", nchars="", special_chars=string.punctuation):
     """
     generates a text string, containing nchars of given type
-
     """
-
-    pool = string.ascii_lowercase + string.digits
-    try:
-        chars = int(chars)
-    except ValueError:
-        raise RefError(f"Ref error: eval_func: {chars} cannot be converted into integer.")
-    ctx.data = "".join(secrets.choice(pool) for i in range(chars))
 
     pool_lookup = {
         "str": string.ascii_letters + string.digits + "-_",
@@ -215,7 +207,7 @@ def random(ctx, type="str", nchars="", special_chars=string.punctuation):
 
     # set ctx.data to generated string
     ctx.data = generated_str
-    
+
 
 def basicauth(ctx, username="", password=""):
     # check if parameters are specified
@@ -235,4 +227,3 @@ def basicauth(ctx, username="", password=""):
 
     # set generated token to ctx.data
     ctx.data = token_b64
-

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -440,3 +440,22 @@ class Base64RefsTest(unittest.TestCase):
         REVEALER._reveal_tag_without_subvar.cache_clear()
         revealed = REVEALER.reveal_raw_file(file_with_tags)
         self.assertEqual(len(revealed), 16)
+
+    def test_ref_function_basicauth(self):
+        "write basicauth to secret, confirm ref file exists, reveal and check"
+        tag = "?{plain:ref/basicauth||basicauth}"
+        REF_CONTROLLER[tag] = RefParams()
+        self.assertTrue(os.path.isfile(os.path.join(REFS_HOME, "ref/basicauth")))
+
+        file_with_tags = tempfile.mktemp()
+        with open(file_with_tags, "w") as fp:
+            fp.write("?{plain:ref/basicauth}")
+        revealed = REVEALER.reveal_raw_file(file_with_tags)
+        self.assertEqual(len(revealed), 24)  # default length of basicauth is 17
+
+        # Test with parameters username=user123 and password=mysecretpassword
+        tag = "?{plain:ref/basicauth||basicauth:user123:mysecretpassword}"
+        REF_CONTROLLER[tag] = RefParams()
+        REVEALER._reveal_tag_without_subvar.cache_clear()
+        revealed = REVEALER.reveal_raw_file(file_with_tags)
+        self.assertEqual(revealed, "dXNlcjEyMzpteXNlY3JldHBhc3N3b3Jk")


### PR DESCRIPTION
## Proposed Changes
  - Added a generator function for basic auth secrets

### Usage
The generator function has two optional arguments: `?{ref:path/to/secret||basicauth:username:password}`
If the arguments are not specified, a text-string containing 8 characters will be generated.

### Examples
- `||basicauth` could generate something like `dddkfrgl:DDwlFByq` as username:password - token
**NOTE:** The secret itself is base64 encoded so it will look like `ZGRka2ZyZ2w6RER3bEZCeXE=`
- `|basicauth:user123:key123` would exactly generate `user123:key123` as token, so the secret (base64) would be `dXNlcjEyMzprZXkxMjM=`

### Testing and docs
Added test for basic auth generator function.
Updated `secret.md` as well.