### PR TITLE
Add HelmChart class to render helm charts as kadet objects

### DIFF
--- a/kapitan/helm_cli.py
+++ b/kapitan/helm_cli.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import subprocess
-from subprocess import PIPE, DEVNULL
+from subprocess import DEVNULL, PIPE
 
 logger = logging.getLogger(__name__)
 

--- a/kapitan/inputs/helm.py
+++ b/kapitan/inputs/helm.py
@@ -255,6 +255,7 @@ class HelmChart(BaseModel):
 
     def body(self):
         # TODO kadet.BaseModel.__init__ must initialise self.root = Dict()
+        # TODO as new BseModel instances will append params globally
         # TODO Doing here until a fix is in kadet module
         self.root = Dict()
         for obj in self.load_chart():

--- a/kapitan/inputs/helm.py
+++ b/kapitan/inputs/helm.py
@@ -1,12 +1,20 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 The Kapitan Authors
+# SPDX-FileCopyrightText: 2020 The Kapitan Authors <kapitan-admins@googlegroups.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 import os
 import tempfile
 
 import yaml
 
-from kapitan.errors import HelmTemplateError
+from kapitan.errors import CompileError, HelmTemplateError
 from kapitan.helm_cli import helm_cli
-from kapitan.inputs.base import InputType, CompiledFile
+from kapitan.inputs.base import CompiledFile, InputType
+from kapitan.inputs.kadet import BaseModel, BaseObj, Dict
 
 logger = logging.getLogger(__name__)
 
@@ -17,6 +25,8 @@ HELM_DENIED_FLAGS = {
     "output-dir",
     "show-only",
 }
+
+HELM_DEFAULT_FLAGS = {"--include-crds": True, "--skip-tests": True}
 
 
 class Helm(InputType):
@@ -30,10 +40,7 @@ class Helm(InputType):
 
         self.helm_values_file = None
         if "helm_values" in args:
-            """dump helm values into a yaml file whose path will be passed over to Go helm code"""
-            _, self.helm_values_file = tempfile.mkstemp(".helm_values.yml", text=True)
-            with open(self.helm_values_file, "w") as fp:
-                yaml.safe_dump(args["helm_values"], fp)
+            self.helm_values_file = write_helm_values_file(args["helm_values"])
 
         self.kube_version = None
         if "kube_version" in args:
@@ -62,7 +69,7 @@ class Helm(InputType):
         temp_dir = tempfile.mkdtemp()
         os.makedirs(os.path.dirname(compile_path), exist_ok=True)
         # save the template output to temp dir first
-        error_message = self.render_chart(
+        _, error_message = self.render_chart(
             chart_dir=file_path,
             output_path=temp_dir,
             helm_path=self.helm_path,
@@ -103,84 +110,164 @@ class Helm(InputType):
     def render_chart(
         self, chart_dir, output_path, helm_path, helm_params, helm_values_file, helm_values_files
     ):
-        args = ["template"]
-
-        name = helm_params.pop("name", None)
-        output_file = helm_params.pop("output_file", None)
-
-        flags = {"--include-crds": True, "--skip-tests": True}
-
+        helm_flags = dict(HELM_DEFAULT_FLAGS)
+        # add to flags if set
         if self.kube_version:
-            flags["--api-versions"] = self.kube_version
+            helm_flags["--api-versions"] = self.kube_version
 
-        for param, value in helm_params.items():
-            if len(param) == 1:
-                raise ValueError(f"invalid helm flag: '{param}'. helm_params supports only long flag names")
+        return render_chart(
+            chart_dir,
+            output_path,
+            helm_path,
+            helm_params,
+            helm_values_file,
+            helm_values_files,
+            helm_flags=helm_flags,
+        )
 
-            if "-" in param:
-                raise ValueError(f"helm flag names must use '_' and not '-': {param}")
 
-            param = param.replace("_", "-")
+def render_chart(
+    chart_dir,
+    output_path,
+    helm_path,
+    helm_params,
+    helm_values_file,
+    helm_values_files,
+    helm_flags=None,
+):
+    """
+    Renders chart in chart_dir
+    Returns tuple with output and error_message
+    """
+    args = ["template"]
 
-            if param in ("set", "set-file", "set-string"):
-                raise ValueError(
-                    f"helm '{param}' flag is not supported. Use 'helm_values' to specify template values"
-                )
+    name = helm_params.pop("name", None)
+    output_file = helm_params.pop("output_file", None)
 
-            if param == "values":
-                raise ValueError(
-                    f"helm '{param}' flag is not supported. Use 'helm_values_files' to specify template values files"
-                )
+    if helm_flags is None:
+        helm_flags = HELM_DEFAULT_FLAGS
 
-            if param in HELM_DENIED_FLAGS:
-                raise ValueError(f"helm flag '{param}' is not supported.")
+    for param, value in helm_params.items():
+        if len(param) == 1:
+            raise ValueError(f"invalid helm flag: '{param}'. helm_params supports only long flag names")
 
-            flags[f"--{param}"] = value
+        if "-" in param:
+            raise ValueError(f"helm flag names must use '_' and not '-': {param}")
 
-        # 'release_name' used to be the "helm template" [NAME] parameter.
-        # For backward compatibility, assume it is the '--release-name' flag only if its value is a bool.
-        release_name = flags.get("--release-name")
-        if release_name is not None and not isinstance(release_name, bool):
-            logger.warning(
-                "using 'release_name' to specify the output name is deprecated. Use 'name' instead"
+        param = param.replace("_", "-")
+
+        if param in ("set", "set-file", "set-string"):
+            raise ValueError(
+                f"helm '{param}' flag is not supported. Use 'helm_values' to specify template values"
             )
-            del flags["--release-name"]
-            # name is used in place of release_name if both are specified
-            name = name or release_name
 
-        for flag, value in flags.items():
-            # boolean flag should be passed when present, and omitted when not specified
-            if isinstance(value, bool):
-                if value:
-                    args.append(flag)
-            else:
+        if param == "values":
+            raise ValueError(
+                f"helm '{param}' flag is not supported. Use 'helm_values_files' to specify template values files"
+            )
+
+        if param in HELM_DENIED_FLAGS:
+            raise ValueError(f"helm flag '{param}' is not supported.")
+
+        helm_flags[f"--{param}"] = value
+
+    # 'release_name' used to be the "helm template" [NAME] parameter.
+    # For backward compatibility, assume it is the '--release-name' flag only if its value is a bool.
+    release_name = helm_flags.get("--release-name")
+    if release_name is not None and not isinstance(release_name, bool):
+        logger.warning("using 'release_name' to specify the output name is deprecated. Use 'name' instead")
+        del helm_flags["--release-name"]
+        # name is used in place of release_name if both are specified
+        name = name or release_name
+
+    for flag, value in helm_flags.items():
+        # boolean flag should be passed when present, and omitted when not specified
+        if isinstance(value, bool):
+            if value:
                 args.append(flag)
-                args.append(str(value))
-
-        """renders helm chart located at chart_dir, and stores the output to output_path"""
-        if helm_values_file:
-            args.append("--values")
-            args.append(helm_values_file)
-
-        if helm_values_files:
-            for file_name in helm_values_files:
-                args.append("--values")
-                args.append(file_name)
-
-        if not output_file:
-            args.append("--output-dir")
-            args.append(output_path)
-
-        if "name_template" not in flags:
-            args.append(name or "--generate-name")
-
-        # uses absolute path to make sure helm interprets it as a
-        # local dir and not a chart_name that it should download.
-        args.append(chart_dir)
-
-        if output_file:
-            with open(os.path.join(output_path, output_file), "wb") as f:
-                # can't be verbose when capturing stdout
-                return helm_cli(helm_path, args, stdout=f)
         else:
-            return helm_cli(helm_path, args, verbose="--debug" in flags)
+            args.append(flag)
+            args.append(str(value))
+
+    """renders helm chart located at chart_dir, and stores the output to output_path"""
+    if helm_values_file:
+        args.append("--values")
+        args.append(helm_values_file)
+
+    if helm_values_files:
+        for file_name in helm_values_files:
+            args.append("--values")
+            args.append(file_name)
+
+    if not output_file and output_path not in (None, "-"):
+        args.append("--output-dir")
+        args.append(output_path)
+
+    if "name_template" not in helm_flags:
+        args.append(name or "--generate-name")
+
+    # uses absolute path to make sure helm interprets it as a
+    # local dir and not a chart_name that it should download.
+    args.append(chart_dir)
+
+    # If output_path is '-', output is a string with rendered chart
+    if output_path == "-":
+        _, helm_output = tempfile.mkstemp(".helm_output.yml", text=True)
+        with open(helm_output, "w+") as f:
+            error_message = helm_cli(helm_path, args, stdout=f)
+            f.seek(0)
+            return (f.read(), error_message)
+
+    if output_file:
+        with open(os.path.join(output_path, output_file), "wb") as f:
+            # can't be verbose when capturing stdout
+            error_message = helm_cli(helm_path, args, stdout=f)
+            return ("", error_message)
+    else:
+        error_message = helm_cli(helm_path, args, verbose="--debug" in helm_flags)
+        return ("", error_message)
+
+
+def write_helm_values_file(helm_values: dict):
+    """
+    Dump helm values into a yaml file whose path will
+    be passed over to helm binary
+    """
+    _, helm_values_file = tempfile.mkstemp(".helm_values.yml", text=True)
+    with open(helm_values_file, "w") as fp:
+        yaml.safe_dump(helm_values, fp)
+
+    return helm_values_file
+
+
+class HelmChart(BaseModel):
+    """
+    Returns rendered helm chart in chart_dir
+    Each rendered file will be a key in self.root
+
+    Requires chart_dir to exist (it will not download it)
+    """
+
+    chart_dir: str
+    helm_params: dict = {}
+    helm_values: dict = {}
+    helm_path: str = None
+
+    def body(self):
+        # TODO kadet.BaseModel.__init__ must initialise self.root = Dict()
+        # TODO Doing here until a fix is in kadet module
+        self.root = Dict()
+        for obj in self.load_chart():
+            self.root[f"{obj['metadata']['name'].lower()}-{obj['kind'].lower()}"] = BaseObj.from_dict(obj)
+
+    def load_chart(self):
+        helm_values_file = None
+        if self.helm_values != {}:
+            helm_values_file = write_helm_values_file(self.helm_values)
+        output, error_message = render_chart(
+            self.chart_dir, "-", self.helm_path, self.helm_params, helm_values_file, None
+        )
+        if error_message:
+            raise HelmTemplateError(error_message)
+
+        return yaml.safe_load_all(output)

--- a/kapitan/inputs/helm.py
+++ b/kapitan/inputs/helm.py
@@ -253,13 +253,11 @@ class HelmChart(BaseModel):
     helm_values: dict = {}
     helm_path: str = None
 
-    def body(self):
-        # TODO kadet.BaseModel.__init__ must initialise self.root = Dict()
-        # TODO as new BaseModel instances will append params globally
-        # TODO Doing here until a fix is in kadet module
-        self.root = Dict()
+    def new(self):
         for obj in self.load_chart():
-            self.root[f"{obj['metadata']['name'].lower()}-{obj['kind'].lower()}"] = BaseObj.from_dict(obj)
+            self.root[
+                f"{obj['metadata']['name'].lower()}-{obj['kind'].lower().replace(':','-')}"
+            ] = BaseObj.from_dict(obj)
 
     def load_chart(self):
         helm_values_file = None

--- a/kapitan/inputs/helm.py
+++ b/kapitan/inputs/helm.py
@@ -255,7 +255,7 @@ class HelmChart(BaseModel):
 
     def body(self):
         # TODO kadet.BaseModel.__init__ must initialise self.root = Dict()
-        # TODO as new BseModel instances will append params globally
+        # TODO as new BaseModel instances will append params globally
         # TODO Doing here until a fix is in kadet module
         self.root = Dict()
         for obj in self.load_chart():

--- a/requirements.txt
+++ b/requirements.txt
@@ -108,7 +108,7 @@ jsonnet==0.18.0
     # via -r requirements.txt
 jsonschema==3.2.0
     # via -r requirements.txt
-kadet==0.2.1
+kadet==0.2.2
     # via -r requirements.txt
 markupsafe==2.0.1
     # via

--- a/tests/test_helm_input.py
+++ b/tests/test_helm_input.py
@@ -15,7 +15,8 @@ import yaml
 
 from kapitan.cached import reset_cache
 from kapitan.cli import main
-from kapitan.inputs.helm import Helm
+from kapitan.inputs.helm import Helm, HelmChart
+from kapitan.inputs.kadet import BaseObj
 
 
 class HelmInputTest(unittest.TestCase):
@@ -193,6 +194,16 @@ class HelmInputTest(unittest.TestCase):
                 )
             )
             self.assertIn("--election-id=super_secret_ID", args)
+
+    def test_compile_kadet_helm_chart(self):
+        # Render chart
+        chart = HelmChart(chart_dir="charts/prometheus/")
+
+        # Number of keys must be greater than 0
+        self.assertTrue(len(chart.root.keys()) > 0)
+        # All values must be BaseObj
+        for resource_name in chart.root:
+            self.assertIsInstance(chart.root[resource_name], BaseObj)
 
     def tearDown(self):
         os.chdir("../../")

--- a/tests/test_helm_input.py
+++ b/tests/test_helm_input.py
@@ -26,7 +26,7 @@ class HelmInputTest(unittest.TestCase):
         temp_dir = tempfile.mkdtemp()
         chart_path = "charts/acs-engine-autoscaler"
         helm = Helm(None, None, None, {})
-        error_message = helm.render_chart(
+        _, error_message = helm.render_chart(
             chart_path, temp_dir, None, {"name": "acs-engine-autoscaler"}, None, None
         )
         self.assertFalse(error_message)
@@ -41,7 +41,7 @@ class HelmInputTest(unittest.TestCase):
         chart_path = "./non-existent"
         temp_dir = tempfile.mkdtemp()
         helm = Helm(None, None, None, {})
-        error_message = helm.render_chart(chart_path, temp_dir, None, {"name": "mychart"}, None, None)
+        _, error_message = helm.render_chart(chart_path, temp_dir, None, {"name": "mychart"}, None, None)
         self.assertTrue("path" in error_message and "not found" in error_message)
 
     def test_compile_chart(self):


### PR DESCRIPTION
Implements support to render helm charts into a kadet object via HelmChart:

```py
>>> from kapitan.inputs.helm import HelmChart
 
>>> c = HelmChart(chart_dir='tests/test_resources/charts/nginx-ingress', helm_params={'name':'demo'})
>>> list(c.root.keys())
['demo-nginx-ingress-serviceaccount',
 'demo-nginx-ingress-clusterrole',
 'demo-nginx-ingress-clusterrolebinding',
 'demo-nginx-ingress-role',
 'demo-nginx-ingress-rolebinding',
 'demo-nginx-ingress-controller-service',
 'demo-nginx-ingress-default-backend-service',
 'demo-nginx-ingress-controller-deployment',
 'demo-nginx-ingress-default-backend-deployment']

c.root.demo_nginx_ingress_serviceaccount.root.metadata.name = 'my-new-name'

>>> print(c.root.demo_nginx_ingress_serviceaccount.root)
{'apiVersion': 'v1', 'kind': 'ServiceAccount', 
 'metadata': {'labels': {'app': 'nginx-ingress', 'chart': 'nginx-ingress-1.7.0', 'heritage': 'Helm', 'release': 'demo'},
 'name': 'my-new-name'}}
```