### PR TITLE
Add short name `-L` for flag `--yaml-multiline-string-style`

### DIFF
--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -278,6 +278,7 @@ def build_parser():
 
     compile_parser.add_argument(
         "--yaml-multiline-string-style",
+        "-L",
         type=str,
         choices=["literal", "folded", "double-quotes"],
         metavar="STYLE",


### PR DESCRIPTION
## Proposed Changes
* Add short name `-L` for flag `--yaml-multiline-string-style`
* Reference: https://github.com/kapicorp/kapitan/pull/877#issuecomment-1320969754 
