### PR TITLE
Fix subvar for plain 

### DIFF
--- a/docs/references.md
+++ b/docs/references.md
@@ -10,7 +10,7 @@ Kapitan has a built in support for **References**, which you can use to manage b
 |----------------|------------------------------------------------------------|------------------|
 | `plain`        | Plain text, (e.g. commit sha)                              | :material-close: |
 | `base64`       | Base64, non confidential but with base64 encoding          | :material-close: |
-| `gpg`          | Support for <https://gnupg.org/>                             | :material-check: |
+| `gpg`          | Support for <https://gnupg.org/>                           | :material-check: |
 | `gkms`         | GCP KMS                                                    | :material-check: |
 | `awskms`       | AWS KMS                                                    | :material-check: |
 | `azkms`        | Azure Key Vault                                            | :material-check: |
@@ -567,7 +567,7 @@ for more convenience.
 
 Please refer to the [CLI reference](/pages/commands/kapitan_compile/#embed-references)
 
-## References subvars (for accessing YAML)
+## YAML SubVars References
 
 Kapitan is also able to use access specific keys in YAML content by using subvars.
 

--- a/docs/references.md
+++ b/docs/references.md
@@ -10,7 +10,7 @@ Kapitan has a built in support for **References**, which you can use to manage b
 |----------------|------------------------------------------------------------|------------------|
 | `plain`        | Plain text, (e.g. commit sha)                              | :material-close: |
 | `base64`       | Base64, non confidential but with base64 encoding          | :material-close: |
-| `gpg`          | Support for https://gnupg.org/                             | :material-check: |
+| `gpg`          | Support for <https://gnupg.org/>                             | :material-check: |
 | `gkms`         | GCP KMS                                                    | :material-check: |
 | `awskms`       | AWS KMS                                                    | :material-check: |
 | `azkms`        | Azure Key Vault                                            | :material-check: |
@@ -567,11 +567,27 @@ for more convenience.
 
 Please refer to the [CLI reference](/pages/commands/kapitan_compile/#embed-references)
 
-## YAML References
+## References subvars (for accessing YAML)
 
-Kapitan is also able to use reference to store YAML content that can be later accessed using down to the individual keys. 
+Kapitan is also able to use access specific keys in YAML content by using subvars.
 
-This can be used to store YAML outputs coming straight from other tools. For instance, I could use the GCP `gcloud` command to get all the information about a cluster, and write it into a reference
+For instance given a reference `plain:larder` with content:
+
+```yaml
+food:
+  apples: 1
+```
+
+I could now have an inventory variable like:
+
+```yaml
+parameters:
+  number_of_apples: ?{plain:larder@food.apple}
+```
+
+### Using `subvars` to ingest yaml from command line tools
+
+Subvars can have a very practical use for storing YAML outputs coming straight from other tools. For instance, I could use the GCP `gcloud` command to get all the information about a cluster, and write it into a reference
 
 ```shell
 gcloud container clusters describe \

--- a/kapitan/refs/base.py
+++ b/kapitan/refs/base.py
@@ -58,6 +58,7 @@ class PlainRef(object):
         return value
 
     def compile(self):
+        # plain is not using the reveal function, and so we want to look for subvars here
         if self.embedded_subvar_path:
             data = base64.b64decode(self.data).decode("utf-8") if self.encoding == "base64" else self.data
             yaml_data = yaml.load(data, Loader=YamlLoader)
@@ -185,7 +186,7 @@ class PlainRefBackend(object):
                 pass
 
 
-class Revealer(object):
+class _reveal_replace_match(object):
     def __init__(self, ref_controller):
         "reveal files and objects"
         self.ref_controller = ref_controller

--- a/kapitan/refs/base.py
+++ b/kapitan/refs/base.py
@@ -186,7 +186,7 @@ class PlainRefBackend(object):
                 pass
 
 
-class _reveal_replace_match(object):
+class Revealer(object):
     def __init__(self, ref_controller):
         "reveal files and objects"
         self.ref_controller = ref_controller

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -513,58 +513,57 @@ class CliFuncsTest(unittest.TestCase):
         os.remove(test_tag_file)
 
     def test_cli_secret_subvar_ref(self):
-        
-      def _test_cli_secret_subvar_generic_ref(self, reftype):
-        """
-        Generic function to test subvars
-        run $ kapitan refs --write reftype:test_secret
-        and $ kapitan refs --reveal -f sometest_file
-        """
-        test_secret_content = """
+        def _test_cli_secret_subvar_generic_ref(self, reftype):
+            """
+            Generic function to test subvars
+            run $ kapitan refs --write reftype:test_secret
+            and $ kapitan refs --reveal -f sometest_file
+            """
+            test_secret_content = """
         var1:
           var2: hello
         var3:
           var4: world
         """
-        test_secret_file = tempfile.mktemp()
-        with open(test_secret_file, "w") as fp:
-            fp.write(test_secret_content)
+            test_secret_file = tempfile.mktemp()
+            with open(test_secret_file, "w") as fp:
+                fp.write(test_secret_content)
 
-        sys.argv = [
-            "kapitan",
-            "refs",
-            "--write",
-            f"{reftype}:test_secret_subvar",
-            "-f",
-            test_secret_file,
-            "--refs-path",
-            REFS_PATH,
-        ]
-        main()
+            sys.argv = [
+                "kapitan",
+                "refs",
+                "--write",
+                f"{reftype}:test_secret_subvar",
+                "-f",
+                test_secret_file,
+                "--refs-path",
+                REFS_PATH,
+            ]
+            main()
 
-        test_tag_content = f"""
+            test_tag_content = f"""
         revealing1: ?{{{reftype}}}:test_secret_subvar@var1.var2}}
         revealing2: ?{{{reftype}}}:test_secret_subvar@var3.var4}}
         """
-        test_tag_file = tempfile.mktemp()
-        with open(test_tag_file, "w") as fp:
-            fp.write(test_tag_content)
-        sys.argv = ["kapitan", "refs", "--reveal", "-f", test_tag_file, "--refs-path", REFS_PATH]
+            test_tag_file = tempfile.mktemp()
+            with open(test_tag_file, "w") as fp:
+                fp.write(test_tag_content)
+            sys.argv = ["kapitan", "refs", "--reveal", "-f", test_tag_file, "--refs-path", REFS_PATH]
 
-        # set stdout as string
-        stdout = io.StringIO()
-        with contextlib.redirect_stdout(stdout):
-            main()
+            # set stdout as string
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
+                main()
 
-        expected = """
+            expected = """
         revealing1: {}
         revealing2: {}
         """
-        self.assertEqual(expected.format("hello", "world"), stdout.getvalue())
-        os.remove(test_tag_file)
-    
-        _test_cli_secret_subvar_generic_ref(self, "plain")
-        _test_cli_secret_subvar_generic_ref(self, "base64")
+            self.assertEqual(expected.format("hello", "world"), stdout.getvalue())
+            os.remove(test_tag_file)
+
+            _test_cli_secret_subvar_generic_ref(self, "plain")
+            _test_cli_secret_subvar_generic_ref(self, "base64")
 
     def test_cli_secret_subvar_gpg(self):
         """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -512,9 +512,12 @@ class CliFuncsTest(unittest.TestCase):
 
         os.remove(test_tag_file)
 
-    def test_cli_secret_subvar_base64_ref(self):
+    def test_cli_secret_subvar_ref(self):
+        
+      def _test_cli_secret_subvar_generic_ref(self, reftype):
         """
-        run $ kapitan refs --write base64:test_secret
+        Generic function to test subvars
+        run $ kapitan refs --write reftype:test_secret
         and $ kapitan refs --reveal -f sometest_file
         """
         test_secret_content = """
@@ -531,7 +534,7 @@ class CliFuncsTest(unittest.TestCase):
             "kapitan",
             "refs",
             "--write",
-            "base64:test_secret_subvar",
+            f"{reftype}:test_secret_subvar",
             "-f",
             test_secret_file,
             "--refs-path",
@@ -539,9 +542,9 @@ class CliFuncsTest(unittest.TestCase):
         ]
         main()
 
-        test_tag_content = """
-        revealing1: ?{base64:test_secret_subvar@var1.var2}
-        revealing2: ?{base64:test_secret_subvar@var3.var4}
+        test_tag_content = f"""
+        revealing1: ?{{{reftype}}}:test_secret_subvar@var1.var2}}
+        revealing2: ?{{{reftype}}}:test_secret_subvar@var3.var4}}
         """
         test_tag_file = tempfile.mktemp()
         with open(test_tag_file, "w") as fp:
@@ -559,6 +562,9 @@ class CliFuncsTest(unittest.TestCase):
         """
         self.assertEqual(expected.format("hello", "world"), stdout.getvalue())
         os.remove(test_tag_file)
+    
+        _test_cli_secret_subvar_generic_ref(self, "plain")
+        _test_cli_secret_subvar_generic_ref(self, "base64")
 
     def test_cli_secret_subvar_gpg(self):
         """


### PR DESCRIPTION
Fixes issue #899

## Proposed Changes

### Make `subvars` fork for
* plain references
* references with base64 encoding (it will temporarily decode and re-encode)
