### PR TITLE
Add missing flags in kapitan_compile.md

### DIFF
--- a/docs/pages/commands/kapitan_compile.md
+++ b/docs/pages/commands/kapitan_compile.md
@@ -72,34 +72,34 @@ Compiles one or more targets selected matching **labels** with  `--labels` or `-
 
     see [**Labels**](/inventory/#target-labels) for more details 
 
-```shell
-$ kapitan compile -l customer=acme
-Compiled acme-project (0.14s)
-Compiled acme-pipelines (0.10s)
-```
+    ```shell
+    $ kapitan compile -l customer=acme
+    Compiled acme-project (0.14s)
+    Compiled acme-pipelines (0.10s)
+    ```
 
 ## Fetch on compile
 
 Use the `--fetch` flag to fetch [**Remote Inventories**](/inventory/#remote-inventories) and the [**External Dependencies**](/external_dependencies/).
 
-```shell
-kapitan compile --fetch
-```
+    ```shell
+    kapitan compile --fetch
+    ```
 
 This will download the dependencies according to their configurations
 By default, kapitan does not overwrite an existing item with the same name as that of the fetched inventory items.
 
 Use the `--force-fetch` flag to force fetch (update cache with freshly fetched items) and overwrite inventory items of the same name in the `output_path`.
 
-```shell
-kapitan compile --force-fetch
-```
+    ```shell
+    kapitan compile --force-fetch
+    ```
 
 Use the `--cache` flag to cache the fetched items in the `.dependency_cache` directory in the root project directory.
 
-```shell
-kapitan compile --cache --fetch
-```
+    ```shell
+    kapitan compile --cache --fetch
+    ```
 
 ## Embed references
 
@@ -172,6 +172,7 @@ The `--embed-refs` flags tells **Kapitan** to embed these references on compile,
           --quiet               set quiet mode, only critical output
           --output-path PATH    set output path, default is "."
           --fetch               fetch remote inventories and/or external dependencies
+          --force-fetch         overwrite existing inventory and/or dependency item
           --force               overwrite existing inventory and/or dependency item
           --validate            validate compile output against schemas as specified
                                 in inventory
@@ -193,10 +194,17 @@ The `--embed-refs` flags tells **Kapitan** to embed these references on compile,
                                 []
           --ignore-version-check
                                 ignore the version from .kapitan
+          --use-go-jsonnet      use go-jsonnet
           --schemas-path SCHEMAS_PATH
                                 set schema cache path, default is "./schemas"
+          --yaml-multiline-string-style STYLE, -L STYLE
+                                set multiline string style to STYLE, default is
+                                'double-quotes'
+          --yaml-dump-null-as-empty
+                                dumps all none-type entries as empty, default is
+                                dumping as 'null'
           --targets TARGET [TARGET ...], -t TARGET [TARGET ...]
                                 targets to compile, default is all
-          --labels [key=value [key=value ...]], -l [key=value [key=value ...]]
+          --labels [key=value ...], -l [key=value ...]
                                 compile targets matching the labels, default is all
           ```


### PR DESCRIPTION
## Proposed Changes
- Add missing or updated cli-flags to `kapitan_compile.md`
- Fix indentation for some code blocks due to the markdown linter
