### PR TITLE
fix #906: Jinja input_params gets reset

### DIFF
--- a/kapitan/inputs/jinja2.py
+++ b/kapitan/inputs/jinja2.py
@@ -30,7 +30,7 @@ class Jinja2(InputType):
         """
         reveal = kwargs.get("reveal", False)
         target_name = kwargs.get("target_name", None)
-        
+
         input_params = self.input_params
         # set compile_path allowing jsonnet to have context on where files
         # are being compiled on the current kapitan run
@@ -42,7 +42,7 @@ class Jinja2(InputType):
         context["inventory"] = inventory(self.search_paths, target_name)
         context["inventory_global"] = inventory(self.search_paths, None)
         context["input_params"] = input_params
-        
+
         jinja2_filters = kwargs.get("jinja2_filters")
 
         for item_key, item_value in render_jinja2(

--- a/kapitan/inputs/jinja2.py
+++ b/kapitan/inputs/jinja2.py
@@ -16,11 +16,8 @@ logger = logging.getLogger(__name__)
 
 
 class Jinja2(InputType):
-    def __init__(self, compile_path, search_paths, ref_controller):
+    def __init__(self, compile_path, search_paths, ref_controller, input_params={}):
         super().__init__("jinja2", compile_path, search_paths, ref_controller)
-        self.input_params = {}
-
-    def set_input_params(self, input_params):
         self.input_params = input_params
 
     def compile_file(self, file_path, compile_path, ext_vars, **kwargs):
@@ -33,14 +30,19 @@ class Jinja2(InputType):
         """
         reveal = kwargs.get("reveal", False)
         target_name = kwargs.get("target_name", None)
+        
+        input_params = self.input_params
+        # set compile_path allowing jsonnet to have context on where files
+        # are being compiled on the current kapitan run
+        # we only do this if user didn't pass its own value
+        input_params.setdefault("compile_path", compile_path)
 
         # set ext_vars and inventory for jinja2 context
         context = ext_vars.copy()
         context["inventory"] = inventory(self.search_paths, target_name)
         context["inventory_global"] = inventory(self.search_paths, None)
-        context["input_params"] = self.input_params
-        # reset between each compile if jinja2 component is used multiple times
-        self.input_params = {}
+        context["input_params"] = input_params
+        
         jinja2_filters = kwargs.get("jinja2_filters")
 
         for item_key, item_value in render_jinja2(

--- a/kapitan/inputs/kadet.py
+++ b/kapitan/inputs/kadet.py
@@ -82,11 +82,8 @@ def load_from_search_paths(module_name):
 
 
 class Kadet(InputType):
-    def __init__(self, compile_path, search_paths, ref_controller):
+    def __init__(self, compile_path, search_paths, ref_controller, input_params={}):
         super().__init__("kadet", compile_path, search_paths, ref_controller)
-        self.input_params = {}
-
-    def set_input_params(self, input_params):
         self.input_params = input_params
 
     def compile_file(self, file_path, compile_path, ext_vars, **kwargs):
@@ -113,9 +110,8 @@ class Kadet(InputType):
         input_params = self.input_params
         # set compile_path allowing kadet functions to have context on where files
         # are being compiled on the current kapitan run
-        input_params["compile_path"] = compile_path
-        # reset between each compile if kadet component is used multiple times
-        self.input_params = {}
+        # we only do this if user didn't pass its own value
+        input_params.setdefault("compile_path", compile_path)
 
         kadet_module, spec = module_from_path(file_path)
         sys.modules[spec.name] = kadet_module

--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -471,17 +471,14 @@ def compile_target(target_obj, search_paths, compile_path, ref_controller, globa
     for comp_obj in compile_objs:
         input_type = comp_obj["input_type"]
         output_path = comp_obj["output_path"]
+        input_params = comp_obj.setdefault("input_params", {})
 
         if input_type == "jinja2":
-            input_compiler = Jinja2(compile_path, search_paths, ref_controller)
-            if "input_params" in comp_obj:
-                input_compiler.set_input_params(comp_obj["input_params"])
+            input_compiler = Jinja2(compile_path, search_paths, ref_controller, input_params=input_params)
         elif input_type == "jsonnet":
             input_compiler = Jsonnet(compile_path, search_paths, ref_controller, use_go=use_go_jsonnet)
         elif input_type == "kadet":
-            input_compiler = Kadet(compile_path, search_paths, ref_controller)
-            if "input_params" in comp_obj:
-                input_compiler.set_input_params(comp_obj["input_params"])
+            input_compiler = Kadet(compile_path, search_paths, ref_controller, input_params=input_params)
         elif input_type == "helm":
             input_compiler = Helm(compile_path, search_paths, ref_controller, comp_obj)
         elif input_type == "copy":

--- a/tests/test_resources/inventory/targets/jinja2-input-params.yml
+++ b/tests/test_resources/inventory/targets/jinja2-input-params.yml
@@ -7,6 +7,7 @@ parameters:
         input_type: jinja2
         input_paths:
           - templates/pod.yml
+          - templates/pod.yml # test https://github.com/kapicorp/kapitan/issues/906
         input_params:
           name: test1
           namespace: ns1


### PR DESCRIPTION
Fixes issue #906

## Proposed Changes

- do not reset input_params in between compile
- clean up the way input_params are passed to Kadet and Jinja
- also exposes compiled path to jinja (same as Kadet)
- adds test

## Tests before change:

```
kapitan compile -t jinja2-input-params
Rendered inventory (0.04s)

Jinja2 error: failed to render /usr/local/google/home/ademaria/isolabs/kapitan/tests/test_resources/templates/pod.yml: Jinja2 TemplateError: 'dict object' has no attribute 'name', at /usr/local/google/home/ademaria/isolabs/kapitan/tests/test_resources/templates/pod.yml:4
Compile error: failed to compile target: jinja2-input-params
```

## Test after change
```
kapitan compile -t jinja2-input-params
Rendered inventory (0.04s)
Compiled jinja2-input-params (0.01s)
```
