### PR TITLE
more accurate handle for .zip kapitan-dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ RUN apt-get update \
     && apt-get install --no-install-recommends -y \
         git \
         ssh-client \
+        libmagic1 \
         gnupg \
         ca-certificates \
     && apt-get clean \

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -533,8 +533,8 @@ def unpack_downloaded_file(file_path, output_path, content_type):
     """unpacks files of various MIME type and stores it to the output_path"""
 
     if (content_type == None or content_type == "application/octet-stream"):
-      if (re.search(r"^Zip archive data.*", magic.from_file(file_path))):
-        content_type = 'application/zip'
+        if (re.search(r"^Zip archive data.*", magic.from_file(file_path))):
+            content_type = 'application/zip'
 
     if content_type == "application/x-tar":
         tar = tarfile.open(file_path)

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -9,6 +9,7 @@ from __future__ import print_function
 import collections
 import json
 import logging
+import magic
 import math
 import os
 import re
@@ -530,6 +531,11 @@ def make_request(source):
 
 def unpack_downloaded_file(file_path, output_path, content_type):
     """unpacks files of various MIME type and stores it to the output_path"""
+
+    if (content_type == None or content_type == "application/octet-stream"):
+      if (re.search(r"^Zip archive data.*", magic.from_file(file_path))):
+        content_type = 'application/zip'
+
     if content_type == "application/x-tar":
         tar = tarfile.open(file_path)
         tar.extractall(path=output_path)
@@ -551,11 +557,6 @@ def unpack_downloaded_file(file_path, output_path, content_type):
             tar = tarfile.open(file_path)
             tar.extractall(path=output_path)
             tar.close()
-            is_unpacked = True
-        elif re.search(r"\.zip$", file_path):
-            zfile = ZipFile(file_path)
-            zfile.extractall(output_path)
-            zfile.close()
             is_unpacked = True
         else:
             extension = re.findall(r"\..*$", file_path)[0]

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -552,7 +552,7 @@ def unpack_downloaded_file(file_path, output_path, content_type):
             tar.extractall(path=output_path)
             tar.close()
             is_unpacked = True
-        elif (r"\.zip$", file_path):
+        elif re.search(r"\.zip$", file_path):
             zfile = ZipFile(file_path)
             zfile.extractall(output_path)
             zfile.close()

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -533,7 +533,7 @@ def unpack_downloaded_file(file_path, output_path, content_type):
     """unpacks files of various MIME type and stores it to the output_path"""
 
     if (content_type == None or content_type == "application/octet-stream"):
-        if (re.search(r"^Zip archive data.*", magic.from_file(file_path))):
+        if re.search(r"^Zip archive data.*", magic.from_file(file_path)):
             content_type = 'application/zip'
 
     if content_type == "application/x-tar":

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -552,6 +552,11 @@ def unpack_downloaded_file(file_path, output_path, content_type):
             tar.extractall(path=output_path)
             tar.close()
             is_unpacked = True
+        elif (r"\.zip$", file_path):
+            zfile = ZipFile(file_path)
+            zfile.extractall(output_path)
+            zfile.close()
+            is_unpacked = True
         else:
             extension = re.findall(r"\..*$", file_path)[0]
             logger.debug("File extension %s not suported", extension)

--- a/requirements.txt
+++ b/requirements.txt
@@ -188,6 +188,8 @@ python-dateutil==2.8.2
     #   botocore
 python-gnupg==0.4.7
     # via -r requirements.txt
+python-magic==0.4.27
+    # via -r requirements.txt
 pytz==2021.1
     # via
     #   -r requirements.txt


### PR DESCRIPTION
I have the following dependency in kapitan:

```yaml
...
  kapitan:
    dependencies:
      - type: http
        output_path: ./freeplane/freeplane.zip
        source: https://sourceforge.net/projects/freeplane/files/freeplane%20stable/freeplane_bin-1.10.6.zip/download
        unpack: true
...
```

without this patch, the `kapitan compile --fetch` leads to 
```bash
$ kapitan compile --fetch 
Dependency https://sourceforge.net/projects/freeplane/files/freeplane%20stable/freeplane_bin-1.10.6.zip/download: fetching now                        
Dependency https://sourceforge.net/projects/freeplane/files/freeplane%20stable/freeplane_bin-1.10.6.zip/download: successfully fetched                
Dependency https://sourceforge.net/projects/freeplane/files/freeplane%20stable/freeplane_bin-1.10.6.zip/download: Content-Type application/octet-stream is not supported for unpack. Ignoring save 
...
```

with patch:
```
$ kapitan compile --fetch
Dependency https://sourceforge.net/projects/freeplane/files/freeplane%20stable/freeplane_bin-1.10.6.zip/download: fetching now
Dependency https://sourceforge.net/projects/freeplane/files/freeplane%20stable/freeplane_bin-1.10.6.zip/download: successfully fetched
Dependency https://sourceforge.net/projects/freeplane/files/freeplane%20stable/freeplane_bin-1.10.6.zip/download: extracted to freeplane/freeplane.zip
...
```