### PR TITLE
feat/strip-j2-jinja: implement rstrip for jinja2 input

### DIFF
--- a/kapitan/inputs/jinja2.py
+++ b/kapitan/inputs/jinja2.py
@@ -16,9 +16,11 @@ logger = logging.getLogger(__name__)
 
 
 class Jinja2(InputType):
-    def __init__(self, compile_path, search_paths, ref_controller):
+    def __init__(self, compile_path, search_paths, ref_controller, args):
         super().__init__("jinja2", compile_path, search_paths, ref_controller)
         self.input_params = {}
+        self.strip_postfix = args.get("strip_postfix", False)
+        self.stripped_postfix = args.get("stripped_postfix", ".j2")
 
     def set_input_params(self, input_params):
         self.input_params = input_params
@@ -34,6 +36,7 @@ class Jinja2(InputType):
         reveal = kwargs.get("reveal", False)
         target_name = kwargs.get("target_name", None)
 
+
         # set ext_vars and inventory for jinja2 context
         context = ext_vars.copy()
         context["inventory"] = inventory(self.search_paths, target_name)
@@ -46,8 +49,9 @@ class Jinja2(InputType):
         for item_key, item_value in render_jinja2(
             file_path, context, jinja2_filters=jinja2_filters, search_paths=self.search_paths
         ).items():
+            if self.strip_postfix and item_key.endswith(self.stripped_postfix):
+                item_key = item_key.rstrip(self.stripped_postfix)
             full_item_path = os.path.join(compile_path, item_key)
-
             with CompiledFile(
                 full_item_path, self.ref_controller, mode="w", reveal=reveal, target_name=target_name
             ) as fp:

--- a/kapitan/inputs/jinja2.py
+++ b/kapitan/inputs/jinja2.py
@@ -19,8 +19,8 @@ class Jinja2(InputType):
     def __init__(self, compile_path, search_paths, ref_controller, args):
         super().__init__("jinja2", compile_path, search_paths, ref_controller)
         self.input_params = {}
-        self.strip_postfix = args.get("strip_postfix", False)
-        self.stripped_postfix = args.get("stripped_postfix", ".j2")
+        self.strip_postfix = args.get("suffix_remove", False)
+        self.stripped_postfix = args.get("suffix_stripped", ".j2")
 
     def set_input_params(self, input_params):
         self.input_params = input_params

--- a/kapitan/inputs/jinja2.py
+++ b/kapitan/inputs/jinja2.py
@@ -36,7 +36,6 @@ class Jinja2(InputType):
         reveal = kwargs.get("reveal", False)
         target_name = kwargs.get("target_name", None)
 
-
         # set ext_vars and inventory for jinja2 context
         context = ext_vars.copy()
         context["inventory"] = inventory(self.search_paths, target_name)

--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -602,7 +602,7 @@ def valid_target_obj(target_obj, require_compile=True):
                         "env_vars": {"type": "object"},
                         "args": {"type": "array"},
                         "suffix_remove": {"type": "boolean"},
-                        "suffix_stripped": {"type": "string"}
+                        "suffix_stripped": {"type": "string"},
                     },
                     "required": ["input_type", "input_paths", "output_path"],
                     "minItems": 1,

--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -601,8 +601,8 @@ def valid_target_obj(target_obj, require_compile=True):
                         "input_params": {"type": "object"},
                         "env_vars": {"type": "object"},
                         "args": {"type": "array"},
-                        "strip_postfix": {"type": "boolean"},
-                        "stripped_postfix": {"type": "string"}
+                        "suffix_remove": {"type": "boolean"},
+                        "suffix_stripped": {"type": "string"}
                     },
                     "required": ["input_type", "input_paths", "output_path"],
                     "minItems": 1,

--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -473,7 +473,7 @@ def compile_target(target_obj, search_paths, compile_path, ref_controller, globa
         output_path = comp_obj["output_path"]
 
         if input_type == "jinja2":
-            input_compiler = Jinja2(compile_path, search_paths, ref_controller)
+            input_compiler = Jinja2(compile_path, search_paths, ref_controller, comp_obj)
             if "input_params" in comp_obj:
                 input_compiler.set_input_params(comp_obj["input_params"])
         elif input_type == "jsonnet":
@@ -601,6 +601,8 @@ def valid_target_obj(target_obj, require_compile=True):
                         "input_params": {"type": "object"},
                         "env_vars": {"type": "object"},
                         "args": {"type": "array"},
+                        "strip_postfix": {"type": "boolean"},
+                        "stripped_postfix": {"type": "string"}
                     },
                     "required": ["input_type", "input_paths", "output_path"],
                     "minItems": 1,

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -106,6 +106,36 @@ class CompileTestResourcesTestJinja2InputParams(unittest.TestCase):
         reset_cache()
 
 
+class CompileTestResourcesTestJinja2PostfixStrip(unittest.TestCase):
+    def setUp(self):
+        os.chdir(os.getcwd() + "/tests/test_resources/")
+
+    def test_compile(self):
+        sys.argv = ["kapitan", "compile", "-t", "jinja2-postfix-strip"]
+        main()
+
+    def test_compile_postfix_strip_disabled(self):
+        self.assertListEqual(
+            os.listdir("compiled/jinja2-postfix-strip/unstripped"),
+            ["stub.txt.j2"]
+        )
+
+    def test_compile_postfix_strip_overridden(self):
+        self.assertListEqual(
+            os.listdir("compiled/jinja2-postfix-strip/stripped-overridden"),
+            ["stub"]
+        )
+
+    def test_compile_postfix_strip_enabled(self):
+        self.assertListEqual(
+            os.listdir("compiled/jinja2-postfix-strip/stripped"),
+            ["stub.txt"]
+        )
+
+    def tearDown(self):
+        os.chdir(os.getcwd() + "/../../")
+        reset_cache()
+
 class CompileKubernetesTest(unittest.TestCase):
     def setUp(self):
         os.chdir(os.getcwd() + "/examples/kubernetes/")

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -115,26 +115,18 @@ class CompileTestResourcesTestJinja2PostfixStrip(unittest.TestCase):
         main()
 
     def test_compile_postfix_strip_disabled(self):
-        self.assertListEqual(
-            os.listdir("compiled/jinja2-postfix-strip/unstripped"),
-            ["stub.txt.j2"]
-        )
+        self.assertListEqual(os.listdir("compiled/jinja2-postfix-strip/unstripped"), ["stub.txt.j2"])
 
     def test_compile_postfix_strip_overridden(self):
-        self.assertListEqual(
-            os.listdir("compiled/jinja2-postfix-strip/stripped-overridden"),
-            ["stub"]
-        )
+        self.assertListEqual(os.listdir("compiled/jinja2-postfix-strip/stripped-overridden"), ["stub"])
 
     def test_compile_postfix_strip_enabled(self):
-        self.assertListEqual(
-            os.listdir("compiled/jinja2-postfix-strip/stripped"),
-            ["stub.txt"]
-        )
+        self.assertListEqual(os.listdir("compiled/jinja2-postfix-strip/stripped"), ["stub.txt"])
 
     def tearDown(self):
         os.chdir(os.getcwd() + "/../../")
         reset_cache()
+
 
 class CompileKubernetesTest(unittest.TestCase):
     def setUp(self):

--- a/tests/test_resources/compiled/jinja2-postfix-strip/stripped-overridden/stub
+++ b/tests/test_resources/compiled/jinja2-postfix-strip/stripped-overridden/stub
@@ -1,0 +1,2 @@
+Is this a Jinja2 template?
+  Yes!

--- a/tests/test_resources/compiled/jinja2-postfix-strip/stripped/stub.txt
+++ b/tests/test_resources/compiled/jinja2-postfix-strip/stripped/stub.txt
@@ -1,0 +1,2 @@
+Is this a Jinja2 template?
+  Yes!

--- a/tests/test_resources/compiled/jinja2-postfix-strip/unstripped/stub.txt.j2
+++ b/tests/test_resources/compiled/jinja2-postfix-strip/unstripped/stub.txt.j2
@@ -1,0 +1,2 @@
+Is this a Jinja2 template?
+  Yes!

--- a/tests/test_resources/inventory/targets/jinja2-postfix-strip.yml
+++ b/tests/test_resources/inventory/targets/jinja2-postfix-strip.yml
@@ -10,7 +10,7 @@ parameters:
         input_params:
           name: test1
           namespace: ns1
-        strip_postfix: true
+        suffix_remove: true
       - output_path: stripped-overridden/
         input_type: jinja2
         input_paths:
@@ -18,8 +18,8 @@ parameters:
         input_params:
           name: test2
           namespace: ns2
-        strip_postfix: true
-        stripped_postfix: .txt.j2
+        suffix_remove: true
+        suffix_stripped: .txt.j2
       - output_path: unstripped/
         input_type: jinja2
         input_paths:

--- a/tests/test_resources/inventory/targets/jinja2-postfix-strip.yml
+++ b/tests/test_resources/inventory/targets/jinja2-postfix-strip.yml
@@ -1,0 +1,29 @@
+parameters:
+  kapitan:
+    vars:
+      target: jinja2-postfix-strip
+    compile:
+      - output_path: stripped/
+        input_type: jinja2
+        input_paths:
+          - templates/stub.txt.j2
+        input_params:
+          name: test1
+          namespace: ns1
+        strip_postfix: true
+      - output_path: stripped-overridden/
+        input_type: jinja2
+        input_paths:
+          - templates/stub.txt.j2
+        input_params:
+          name: test2
+          namespace: ns2
+        strip_postfix: true
+        stripped_postfix: .txt.j2
+      - output_path: unstripped/
+        input_type: jinja2
+        input_paths:
+          - templates/stub.txt.j2
+        input_params:
+          name: test2
+          namespace: ns2

--- a/tests/test_resources/templates/stub.txt.j2
+++ b/tests/test_resources/templates/stub.txt.j2
@@ -1,0 +1,4 @@
+Is this a Jinja2 template?
+{% if True %}
+  Yes!
+{% endif %}


### PR DESCRIPTION
Added options "strip_postfix" and "stripped_postfix" to jinja2 input. This allows to remove output files extensions which is often the case for jinja2 template files (.j2).

Stripping is disabled by default and default value to strip is ".j2".

Closes issue #805

## Proposed Changes
- add option "strip_postfix" to jinja2 input
- add option "stripped_postfix" to jinja2 input
- optional removal of file postfixes (i.e. extensions) on output files
