### PR TITLE
feat/#256/toml-output-format: implement toml output format

### DIFF
--- a/kapitan/inputs/base.py
+++ b/kapitan/inputs/base.py
@@ -13,6 +13,7 @@ import os
 from collections.abc import Mapping
 
 import yaml
+import toml
 
 from kapitan.errors import CompileError, KapitanError
 from kapitan.refs.base import Revealer
@@ -155,6 +156,20 @@ class CompilingFile(object):
             obj = self.revealer.compile_obj(obj, target_name=target_name)
         if obj:
             json.dump(obj, self.fp, indent=indent)
+            logger.debug("Wrote %s", self.fp.name)
+        else:
+            logger.debug("%s is Empty, skipped writing output", self.fp.name)
+
+    def write_toml(self, obj):
+        """recursively compile or reveal refs and convert obj to toml and write to file"""
+        reveal = self.kwargs.get("reveal", False)
+        target_name = self.kwargs.get("target_name", None)
+        if reveal:
+            obj = self.revealer.reveal_obj(obj)
+        else:
+            obj = self.revealer.compile_obj(obj, target_name=target_name)
+        if obj:
+            toml.dump(obj, self.fp)
             logger.debug("Wrote %s", self.fp.name)
         else:
             logger.debug("%s is Empty, skipped writing output", self.fp.name)

--- a/kapitan/inputs/jsonnet.py
+++ b/kapitan/inputs/jsonnet.py
@@ -149,9 +149,20 @@ class Jsonnet(InputType):
                     indent=indent,
                 ) as fp:
                     fp.write(item_value)
+            elif output == "toml":
+                file_path = os.path.join(compile_path, "%s.%s" % (item_key, output))
+                with CompiledFile(
+                    file_path,
+                    self.ref_controller,
+                    mode="w",
+                    reveal=reveal,
+                    target_name=target_name,
+                    indent=indent,
+                ) as fp:
+                    fp.write_toml(item_value)
             else:
                 raise ValueError(
-                    f"Output type defined in inventory for {file_path} is neither 'json', 'yaml' nor 'plain'"
+                    f"Output type defined in inventory for {file_path} is neither 'json', 'yaml', 'toml' nor 'plain'"
                 )
 
     def default_output_type(self):

--- a/kapitan/inputs/kadet.py
+++ b/kapitan/inputs/kadet.py
@@ -181,9 +181,20 @@ class Kadet(InputType):
                     indent=indent,
                 ) as fp:
                     fp.write(item_value)
+            elif output == "toml":
+                file_path = os.path.join(compile_path, "%s.%s" % (item_key, output))
+                with CompiledFile(
+                    file_path,
+                    self.ref_controller,
+                    mode="w",
+                    reveal=reveal,
+                    target_name=target_name,
+                    indent=indent,
+                ) as fp:
+                    fp.write_toml(item_value)
             else:
                 raise ValueError(
-                    f"Output type defined in inventory for {file_path} is neither 'json', 'yaml' nor 'plain'"
+                    f"Output type defined in inventory for {file_path} is neither 'json', 'yaml', 'toml' nor 'plain'"
                 )
 
     def default_output_type(self):

--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -608,7 +608,7 @@ def valid_target_obj(target_obj, require_compile=True):
                         {
                             "properties": {
                                 "input_type": {"enum": ["jsonnet", "kadet", "copy", "remove"]},
-                                "output_type": {"enum": ["yml", "yaml", "json", "plain"]},
+                                "output_type": {"enum": ["yml", "yaml", "json", "plain", "toml"]},
                             },
                         },
                         {"properties": {"input_type": {"enum": ["jinja2", "helm", "external"]}}},

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -15,6 +15,7 @@ import contextlib
 import glob
 import shutil
 import yaml
+import toml
 from kapitan.cli import main
 from kapitan.utils import directory_hash
 from kapitan.cached import reset_cache
@@ -221,5 +222,42 @@ class PlainOutputTest(unittest.TestCase):
         self.assertEqual(compiled_dir_hash, test_compiled_dir_hash)
 
     def tearDown(self):
+        os.chdir(os.getcwd() + "/../../")
+        reset_cache()
+
+
+class TomlOutputTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        os.chdir(os.getcwd() + "/tests/test_resources/")
+        sys.argv = ["kapitan", "compile", "-t", "toml-output"]
+        main()
+
+    def setUp(self):
+        target_file_path = os.path.join(os.getcwd(), "inventory/targets/toml-output.yml")
+        with open(target_file_path) as target_file:
+            target = yaml.safe_load(target_file)
+        self.input_parameter = target["parameters"]["input"]
+
+    def test_jsonnet_output(self):
+        output_file_path = os.path.join(os.getcwd(), "compiled/toml-output/jsonnet-output/nested.toml")
+        expected = self.input_parameter["nested"]
+
+        with open(output_file_path) as output_file:
+            output = toml.load(output_file)
+
+        self.assertDictEqual(output, expected)
+
+    def test_kadet_output(self):
+        output_file_path = os.path.join(os.getcwd(), "compiled/toml-output/kadet-output/nested.toml")
+        expected = self.input_parameter["nested"]
+
+        with open(output_file_path) as output_file:
+            output = toml.load(output_file)
+
+        self.assertDictEqual(output, expected)
+
+    @classmethod
+    def tearDownClass(cls):
         os.chdir(os.getcwd() + "/../../")
         reset_cache()

--- a/tests/test_resources/compiled/toml-output/jsonnet-output/nested.toml
+++ b/tests/test_resources/compiled/toml-output/jsonnet-output/nested.toml
@@ -1,0 +1,3 @@
+[dictionary]
+foo = "bar"
+with_list = [ 1, 2, 3,]

--- a/tests/test_resources/compiled/toml-output/kadet-output/nested.toml
+++ b/tests/test_resources/compiled/toml-output/kadet-output/nested.toml
@@ -1,0 +1,3 @@
+[dictionary]
+foo = "bar"
+with_list = [ 1, 2, 3,]

--- a/tests/test_resources/components/input-to-output/main.jsonnet
+++ b/tests/test_resources/components/input-to-output/main.jsonnet
@@ -1,0 +1,5 @@
+local kap = import "lib/kapitan.libjsonnet";
+local inventory = kap.inventory();
+local p = inventory.parameters;
+
+p.input

--- a/tests/test_resources/inventory/targets/toml-output.yml
+++ b/tests/test_resources/inventory/targets/toml-output.yml
@@ -1,0 +1,26 @@
+parameters:
+  input: 
+    nested:
+      dictionary:
+        foo: bar
+        with_list:
+        - 1
+        - 2
+        - 3
+  kapitan:
+    vars:
+      target: toml-output
+    compile:
+      - name: generate-toml-kadet
+        input_type: kadet
+        output_path: kadet-output
+        output_type: toml
+        input_paths:
+          - kadet_functions/input_to_output
+      - name: generate-toml-jsonnet
+        input_type: jsonnet
+        output_path: jsonnet-output
+        output_type: toml
+        input_paths:
+          - components/input-to-output/main.jsonnet
+          

--- a/tests/test_resources/kadet_functions/input_to_output/__init__.py
+++ b/tests/test_resources/kadet_functions/input_to_output/__init__.py
@@ -1,0 +1,9 @@
+from kapitan.inputs import kadet
+
+
+def main(input_params):
+    inventory = kadet.inventory()
+    output = kadet.BaseObj()
+    for key, value in inventory.parameters.input.items():
+        output.root[key] = kadet.BaseObj.from_dict(value)
+    return output


### PR DESCRIPTION
TOML output format has been added to jsonnet and kadet inputs, along with tests for verification.

Partially covers issue #256 

## Proposed Changes
- support for toml output in jsonnet input
- support for toml output in kadet input
