### PR TITLE
Only propagate env vars which are present for input type `external`

### DIFF
--- a/kapitan/inputs/external.py
+++ b/kapitan/inputs/external.py
@@ -28,10 +28,14 @@ class External(InputType):
         # Propagate HOME and PATH environment variables to external tool
         # This is necessary, because calling `subprocess.run()` with `env` set doesn't propagate
         # any environment variables from the current process.
-        if "PATH" not in env_vars:
-            env_vars["PATH"] = os.environ.get("PATH")
-        if "HOME" not in env_vars:
-            env_vars["HOME"] = os.environ.get("HOME")
+        # We only propagate HOME or PATH if they're present in Kapitan's environment, but aren't
+        # explicitly specified in the input's env_vars already. This ensures we don't run into
+        # issues when spawning the subprocess due to `None` values being present in the subprocess's
+        # environment.
+        if "PATH" not in env_vars and "PATH" in os.environ:
+            env_vars["PATH"] = os.environ["PATH"]
+        if "HOME" not in env_vars and "HOME" in os.environ:
+            env_vars["HOME"] = os.environ["HOME"]
         self.env_vars = env_vars
 
     def set_args(self, args):


### PR DESCRIPTION
## Summary

I've noticed that the current implementation for propagating the environment variables `$HOME` and `$PATH` to the subprocess spawned for the external input type can raise an error if either or both of the variables aren't present in Kapitan's environment.

When one of the variables was missing, the original implementation would propagate value `None` to the subprocess, which causes a `TypeError` when trying to spawn the subprocess:

```
Unknown (Non-Kapitan) error occurred:
multiprocessing.pool.RemoteTraceback:
"""
Traceback (most recent call last):
  File "/usr/lib/python3.8/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/home/simon/work/syn/commodore/.tox/py38/lib/python3.8/site-packages/kapitan/targets.py", line 500, in compile_target
    input_compiler.compile_obj(comp_obj, ext_vars, **kwargs)
  File "/home/simon/work/syn/commodore/.tox/py38/lib/python3.8/site-packages/kapitan/inputs/base.py", line 57, in compile_obj
    self.compile_input_path(input_path, comp_obj, ext_vars, **kwargs)
  File "/home/simon/work/syn/commodore/.tox/py38/lib/python3.8/site-packages/kapitan/inputs/base.py", line 72, in compile_input_path
    self.compile_file(
  File "/home/simon/work/syn/commodore/.tox/py38/lib/python3.8/site-packages/kapitan/inputs/external.py", line 58, in compile_file
    env_vars = {k: compiled_target_pattern.sub(compile_path, v) for (k, v) in self.env_vars.items()}
  File "/home/simon/work/syn/commodore/.tox/py38/lib/python3.8/site-packages/kapitan/inputs/external.py", line 58, in <dictcomp>
    env_vars = {k: compiled_target_pattern.sub(compile_path, v) for (k, v) in self.env_vars.items()}
TypeError: expected string or bytes-like object
```

This commit updates the propagation logic to only propagate `$HOME` and `$PATH` if they're actually present in Kapitan's environment.

Fixes a bug introduced in #864 

## Proposed Changes

- Only propagate `$HOME` and `$PATH` if the corresponding environment variable is present in Kapitan's environment.
