### PR TITLE
Build multi-arch docker images

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -40,11 +40,17 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Build PR/versioned tags
         if: github.ref != 'refs/heads/master'
         uses: docker/build-push-action@v2
         with:
           tags: kapicorp/kapitan:${{ format('{0}', env.REF_NAME ) }}
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}  # push image only on non-pull_requests
           file: Dockerfile
       # TODO push and tag as latest if release (and not RC)
@@ -53,6 +59,7 @@ jobs:
         if: github.ref == 'refs/heads/master'
         with:
           tags: kapicorp/kapitan:${{ format('{0}', env.REF_NAME ) }},kapicorp/kapitan:latest
+          platforms: linux/amd64,linux/arm64
           file: Dockerfile
       - name: Test Dockerfile in current ref
         run: |
@@ -63,4 +70,5 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           tags: kapicorp/kapitan:${{ format('{0}', env.MAJOR_VERSION ) }}
+          platforms: linux/amd64,linux/arm64
           file: Dockerfile

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -40,6 +40,8 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      # Setup QEMU and Buildx to build multi-platform image
+      # This was inspired by this example : https://docs.docker.com/build/ci/github-actions/examples/#multi-platform-images
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Build the virtualenv for Kapitan
 FROM python:3.7-slim AS python-builder
 
+ARG TARGETARCH
+
 RUN mkdir /kapitan
 WORKDIR /kapitan
 
@@ -18,7 +20,7 @@ RUN apt-get update \
         build-essential
 
 # Install Go (for go-jsonnet)
-RUN curl -fsSL -o go.tar.gz https://go.dev/dl/go1.17.3.linux-amd64.tar.gz \
+RUN curl -fsSL -o go.tar.gz https://go.dev/dl/go1.17.3.linux-${TARGETARCH}.tar.gz \
     && tar -C /usr/local -xzf go.tar.gz \
     && rm go.tar.gz
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Releases](https://img.shields.io/github/release/kapicorp/kapitan.svg)](https://github.com/kapicorp/kapitan/releases)
 [![Docker Image Size](https://img.shields.io/docker/image-size/kapicorp/kapitan/latest.svg)](https://hub.docker.com/r/kapicorp/kapitan)
 
-<img src="docs/images/kapitan_logo.png" width="25">  
+<img src="docs/images/kapitan_logo.png" width="25">
 
 
 **`Kapitan`** aims to be your *one-stop tool* to help you manage the ever growing complexity of your configurations.
@@ -52,6 +52,14 @@ System-wide (not recommended):
 ```shell
 sudo pip3 install --upgrade kapitan
 ```
+
+## Build Kapitan
+
+### Docker
+
+To build a docker image for the architecture of your machine, run `docker build . -t you-kapitan-image`, and to build for a specific platform, add `--platform linux/arm64`.
+
+To build a multi-platform image (as the CI does), follow [the docker multi-platform documentation](https://docs.docker.com/build/building/multi-platform/).
 
 ## Related projects
 


### PR DESCRIPTION
Fixes issue #939

## Proposed Changes

On a M1 / M2 mac the performance are 5x worse for our use case if using the amd64 docker.
We would like to have the possibility of using a multi-plateform image, and this PR allows that : 

- Update the Dockerfile to use the TARGETARCH environment variable to pull the correct version of go.
- Update the docker-image github action pipeline to setup QEMU and buildx, 
   and then building multi-plateform images of kapitan.

Building an image on a computer of the same architecture should work as previously. 
I could add some documentation on how to do locally what the CI does (build a multi-arch image with a single tag).

This was inspired by this bit of documentation about building multi-plateform images : https://docs.docker.com/build/ci/github-actions/examples/#multi-platform-images
There is also this more general documentation about how to set this up outside of CI : https://docs.docker.com/build/building/multi-platform/
 