### PR TITLE
Add libmagic to mac install

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -65,7 +65,7 @@
 === "Mac"
 
     ```shell
-    brew install python3 libyaml
+    brew install python3 libyaml libmagic
     ```
 
 #### Install Kapitan using pip


### PR DESCRIPTION
necessary for https://pypi.org/project/python-magic/, which is a sub-dependency. See link.

