### PR TITLE
Fix python version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Kapitan: advanced configuration management tool
 
 ![Unit Tests](https://github.com/kapicorp/kapitan/actions/workflows/test.yml/badge.svg)
-![Python Version](https://img.shields.io/github/pipenv/locked/python-version/kapicorp/kapitan.svg)
+![Python Version](https://img.shields.io/pypi/pyversions/kapitan)
 ![Downloads](https://img.shields.io/pypi/dm/kapitan)
 ![Docker Pulls](https://img.shields.io/docker/pulls/kapicorp/kapitan)
 [![Docker](https://github.com/kapicorp/kapitan/workflows/Docker%20Build%20and%20Push/badge.svg)](https://github.com/kapicorp/kapitan/actions?query=workflow%3A%22Docker+Build+and+Push%22)

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,7 +54,7 @@
 
 #### Install Python
 
-![Python version](https://img.shields.io/github/pipenv/locked/python-version/kapicorp/kapitan.svg)
+![Python version](https://img.shields.io/pypi/pyversions/kapitan)
 ![Unit Tests](https://github.com/kapicorp/kapitan/actions/workflows/test.yml/badge.svg)
 === "Linux"
 


### PR DESCRIPTION
## Proposed Changes
  * Because the `pip.lock` file was deleted the version badge in the readme did not work anymore
  * New badge fetches version from PyPi directly
  * ![version badge](https://img.shields.io/pypi/pyversions/kapitan)

