### PR TITLE
refactor: initialiser package

### DIFF
--- a/kapitan/initialiser.py
+++ b/kapitan/initialiser.py
@@ -11,7 +11,7 @@ import logging
 import os
 from pathlib import Path
 
-from kapitan.utils import copy_tree
+from kapitan.utils import tree, copy_tree
 
 logger = logging.getLogger(__name__)
 
@@ -27,16 +27,6 @@ def initialise_skeleton(args):
     destination = Path(args.directory)
     copied_files = copy_tree(source=templates, destination=destination, dirs_exist_ok=True)
 
-    logger.info("Populated %s with:", args.directory)
-    for directory, _, file_list in os.walk(args.directory):
-        # In order to avoid adding the given directory itself in listing.
-        if directory == args.directory:
-            continue
-        if any([path.startswith(directory) for path in copied_files]):
-            level = directory.replace(args.directory, "").count(os.sep) - 1
-            indent = " " * 4 * (level)
-            logger.info("%s%s", indent, os.path.basename(directory))
-            for fname in file_list:
-                if os.path.join(directory, fname) in copied_files:
-                    sub_indent = " " * 4 * (level + 1)
-                    logger.info("%s%s", sub_indent, fname)
+    logger.info("Populated %s with:", destination)
+    for entry in tree(Path(destination), filter_func=lambda x: str(x) in copied_files):
+        logger.info(entry)

--- a/kapitan/initialiser.py
+++ b/kapitan/initialiser.py
@@ -9,30 +9,34 @@
 
 import logging
 import os
-from distutils.dir_util import copy_tree
+from pathlib import Path
+
+from kapitan.utils import copy_tree
 
 logger = logging.getLogger(__name__)
 
 
 def initialise_skeleton(args):
-    """Initialises a directory with a recommended skeleton structure
-    Args:
-        args.directory (string): path which to initialise, directory is assumed to exist
-    """
+    """Initialises a directory with a recommended skeleton structure and prints list of
+    copied files.
 
-    current_pwd = os.path.dirname(__file__)
-    templates_directory = os.path.join(current_pwd, "inputs", "templates")
-    populated = copy_tree(templates_directory, args.directory)
+    Args:
+        args.directory (string): path which to initialise, directory is assumed to exist.
+    """
+    templates = Path(__file__).resolve().parent.joinpath("inputs", "templates")
+    destination = Path(args.directory)
+    copied_files = copy_tree(source=templates, destination=destination, dirs_exist_ok=True)
+
     logger.info("Populated %s with:", args.directory)
-    for directory, subs, file_list in os.walk(args.directory):
+    for directory, _, file_list in os.walk(args.directory):
         # In order to avoid adding the given directory itself in listing.
         if directory == args.directory:
             continue
-        if any([path.startswith(directory) for path in populated]):
+        if any([path.startswith(directory) for path in copied_files]):
             level = directory.replace(args.directory, "").count(os.sep) - 1
             indent = " " * 4 * (level)
             logger.info("%s%s", indent, os.path.basename(directory))
             for fname in file_list:
-                if os.path.join(directory, fname) in populated:
+                if os.path.join(directory, fname) in copied_files:
                     sub_indent = " " * 4 * (level + 1)
                     logger.info("%s%s", sub_indent, fname)

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -650,3 +650,32 @@ def copy_tree(source: Path, destination: Path, dirs_exist_ok: bool = False) -> L
     copytree(source, destination, dirs_exist_ok=dirs_exist_ok)
     inventory_after = list(destination.rglob("*"))
     return [str(d) for d in inventory_after if d not in inventory_before]
+
+
+def tree(start_path: Path, prefix: str = "", filter_func: callable = lambda a: True) -> None:
+    """A recursive generator, given a directory Path object will yield a visual tree structure
+    line by line with each line prefixed by the same characters. Possible to pass a filter
+    function that takes pathlib.Path and returns either True of False.
+    Taken from https://stackoverflow.com/a/59109706
+    Args:
+        start_path (Path): Path from which tree should be generated.
+        prefix (str, optional): Visual prefix to show the structure. Defaults to ''.
+        filter_func (callable, optional): Function that will apply to each path. Should return boolean.
+        Defaults to lambda a : True.
+    Yields:
+        str: Directory / File with a visual tree pointer.
+    """
+    space = "    "
+    branch = "│   "
+    tee = "├── "
+    last = "└── "
+
+    contents = [p for p in Path(start_path).iterdir() if filter_func(p)]
+    # contents each get pointers that are ├── with a final └── :
+    pointers = [tee] * (len(contents) - 1) + [last]
+    for pointer, path in zip(pointers, contents):
+        yield prefix + pointer + path.name
+        if path.is_dir():  # extend the prefix and recurse:
+            extension = branch if pointer == tee else space
+            # i.e. space because last, └── , above so no more |
+            yield from tree(start_path=path, prefix=prefix + extension, filter_func=filter_func)

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -23,6 +23,9 @@ from distutils.errors import DistutilsFileError
 from distutils.file_util import _copy_file_contents
 from functools import lru_cache, wraps
 from hashlib import sha256
+from pathlib import Path
+from shutil import copytree
+from typing import List
 from zipfile import ZipFile
 
 import jinja2
@@ -631,3 +634,19 @@ def safe_copy_tree(src, dst):
             outputs.append(dst_name)
 
     return outputs
+
+
+def copy_tree(source: Path, destination: Path, dirs_exist_ok: bool = False) -> List[str]:
+    """Recursively copy a given directory from `source` to `destination` using shutil.copytree
+    and returns list of copied files. When `dirs_exist_ok` is set, the `FileExistsError` is
+    ignore when destination directory exists.
+    Args:
+        source (str): Path to a source directory
+        destination (str): Path to a destination directory
+    Returns:
+        list[str]: List of copied files
+    """
+    inventory_before = list(destination.rglob("*"))
+    copytree(source, destination, dirs_exist_ok=dirs_exist_ok)
+    inventory_after = list(destination.rglob("*"))
+    return [str(d) for d in inventory_after if d not in inventory_before]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 The Kapitan Authors
+# SPDX-FileCopyrightText: 2020 The Kapitan Authors <kapitan-admins@googlegroups.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+import tempfile
+from typing import List
+import unittest
+
+from kapitan.utils import copy_tree
+
+
+class CopytreeTest(unittest.TestCase):
+    def _create_directory_structure(self, root: Path, structure: List[str]):
+        for sub_path in structure:
+            full_path = root / sub_path
+            full_path.parent.mkdir(parents=True, exist_ok=True)
+            full_path.touch(exist_ok=True)
+
+    def setUp(self):
+        self.template_structure = [
+            "components/my_component/my_component.jsonnet",
+            "components/other_component/__init__.py",
+            "inventory/classes/common.yml",
+            "inventory/classes/my_component.yml",
+            "templates/docs/my_readme.md",
+            "templates/scripts/my_script.sh",
+        ]
+        self.template_directory = tempfile.TemporaryDirectory()
+        self.template_directory_path = Path(self.template_directory.name)
+
+        self._create_directory_structure(self.template_directory_path, self.template_structure)
+
+    def tearDown(self):
+        self.template_directory.cleanup()
+
+    def test_empty_dir(self):
+        """Validates that all template files were copied to the correct directory and
+        the right list of copied files was returned."""
+        with tempfile.TemporaryDirectory() as destination_directory:
+            template_files = [destination_directory + "/" + f for f in self.template_structure]
+
+            copied_paths = copy_tree(
+                source=self.template_directory_path,
+                destination=Path(destination_directory),
+                dirs_exist_ok=True,
+            )
+            # We only care about files as they will have full patch anyway.
+            copied_files = [p for p in copied_paths if Path(p).is_file()]
+
+            self.assertSequenceEqual(sorted(copied_files), sorted(template_files))
+            self.assertTrue([Path(f).exists() for f in template_files])
+
+    def test_non_empty_dir(self):
+        """Makes sure that existing directories and files are untouched."""
+        with tempfile.TemporaryDirectory() as destination_directory:
+            extra_files = [
+                "file_that_existed_before.txt",
+                "this_existed_before/file.txt",
+            ]
+            self._create_directory_structure(Path(destination_directory), extra_files)
+            template_files = [destination_directory + "/" + f for f in self.template_structure]
+
+            copied_paths = copy_tree(
+                source=self.template_directory_path,
+                destination=Path(destination_directory),
+                dirs_exist_ok=True,
+            )
+            # We only care about files as they will have full patch anyway.
+            copied_files = [p for p in copied_paths if Path(p).is_file()]
+
+            self.assertSequenceEqual(sorted(copied_files), sorted(template_files))
+            self.assertTrue([Path(f).exists() for f in template_files])
+            self.assertTrue([Path(destination_directory + "/" + f).exists() for f in extra_files])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Follow up from #964 

## Proposed Changes
Small refactoring of the `initialiser.py` package. Changes:
 - extracted generating a tree structure to a dedicated function
 - changed a bit output of `initialise_skeleton` for better visibility (see "Testing" section below)

**Testing:**
 - Manually ran `kapitan init --directory` multiple times

   State before each run:
   ```console
    ➜  kapitan git:(master) tree /tmp/kapitan                                                                                                                                                            
    git:(master|)
    /tmp/kapitan
    ├── file_that_existed_before.txt
    └── this_existed_before
        └── file.txt
    
    2 directories, 2 files
    ```

   Old:
   ```console
    ➜  kapitan git:(master) poetry run kapitan init --directory /tmp/kapitan                                                                                                                             git:(master|)
    creating /tmp/kapitan/components
    creating /tmp/kapitan/components/other_component
    copying /Users/jacek/Code/kapitan/kapitan/inputs/templates/components/other_component/__init__.py -> /tmp/kapitan/components/other_component
    creating /tmp/kapitan/components/my_component
    copying /Users/jacek/Code/kapitan/kapitan/inputs/templates/components/my_component/my_component.jsonnet -> /tmp/kapitan/components/my_component
    creating /tmp/kapitan/inventory
    creating /tmp/kapitan/inventory/targets
    copying /Users/jacek/Code/kapitan/kapitan/inputs/templates/inventory/targets/my_target.yml -> /tmp/kapitan/inventory/targets
    creating /tmp/kapitan/inventory/classes
    copying /Users/jacek/Code/kapitan/kapitan/inputs/templates/inventory/classes/common.yml -> /tmp/kapitan/inventory/classes
    copying /Users/jacek/Code/kapitan/kapitan/inputs/templates/inventory/classes/my_component.yml -> /tmp/kapitan/inventory/classes
    creating /tmp/kapitan/templates
    creating /tmp/kapitan/templates/docs
    copying /Users/jacek/Code/kapitan/kapitan/inputs/templates/templates/docs/my_readme.md -> /tmp/kapitan/templates/docs
    creating /tmp/kapitan/templates/scripts
    copying /Users/jacek/Code/kapitan/kapitan/inputs/templates/templates/scripts/my_script.sh -> /tmp/kapitan/templates/scripts
    Populated /tmp/kapitan with:
    components
        other_component
            __init__.py
        my_component
            my_component.jsonnet
    inventory
        targets
            my_target.yml
        classes
            common.yml
            my_component.yml
    templates
        docs
            my_readme.md
        scripts
            my_script.sh

    ➜  kapitan_fork git:(refactor_initialiser_package) ✗ poetry run kapitan init --directory /tmp/kapitan                                                       git:(refactor_initialiser_package|✚2…1
    Populated /tmp/kapitan with:
   ```
    New:
    ```console
    ➜  kapitan_fork git:(refactor_initialiser_package) ✗ poetry run kapitan init --directory /tmp/kapitan                                                       git:(refactor_initialiser_package|✚2…1
    Populated /tmp/kapitan with:
    ├── components
    │   ├── other_component
    │   │   └── __init__.py
    │   └── my_component
    │       └── my_component.jsonnet
    ├── inventory
    │   ├── targets
    │   │   └── my_target.yml
    │   └── classes
    │       ├── common.yml
    │       └── my_component.yml
    └── templates
        ├── docs
        │   └── my_readme.md
        └── scripts
            └── my_script.sh

    ➜  kapitan_fork git:(refactor_initialiser_package) ✗ poetry run kapitan init --directory /tmp/kapitan                                                       git:(refactor_initialiser_package|✚2…1
    Populated /tmp/kapitan with:
    ```
