### PR TITLE
Update golang version used in dockerfile to 1.20.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update \
         build-essential
 
 # Install Go (for go-jsonnet)
-RUN curl -fsSL -o go.tar.gz https://go.dev/dl/go1.17.3.linux-${TARGETARCH}.tar.gz \
+RUN curl -fsSL -o go.tar.gz https://go.dev/dl/go1.20.2.linux-${TARGETARCH}.tar.gz \
     && tar -C /usr/local -xzf go.tar.gz \
     && rm go.tar.gz
 


### PR DESCRIPTION
## Proposed Changes

Each major go release is supported until there are two newer major releases (cf https://go.dev/doc/devel/release) which mean the currently supported go version are 1.19 and 1.20.

Go-jsonnet recommands always using the newest stable release of Go (cf https://github.com/google/go-jsonnet/tree/master#go-jsonnet).

This PR proposes to upgrade the dockerfile golang to the newest stable version.
