### PR TITLE
Fix reclass config-file reading

### DIFF
--- a/kapitan/resources.py
+++ b/kapitan/resources.py
@@ -340,9 +340,7 @@ def inventory_reclass(inventory_path, ignore_class_notfound=False):
             for key, value in config.items():
                 reclass_config[key] = value
         else:
-            logger.debug(
-                "{}: Empty config file. Using reclass inventory config defaults".format(cfg_file)
-            )
+            logger.debug("{}: Empty config file. Using reclass inventory config defaults".format(cfg_file))
     else:
         logger.debug("Inventory reclass: No config file found. Using reclass inventory config defaults")
 

--- a/kapitan/resources.py
+++ b/kapitan/resources.py
@@ -334,7 +334,7 @@ def inventory_reclass(inventory_path, ignore_class_notfound=False):
     if os.path.isfile(cfg_file):
         with open(cfg_file, "r") as fp:
             config = yaml.load(fp.read(), Loader=YamlLoader)
-            logger.debug("Using reclass inventory config at: %s", cfg_file)
+            logger.debug("Using reclass inventory config at: {}".format(cfg_file))
         if config:
             # set attributes, take default values if not present
             for key, value in config.items():

--- a/kapitan/resources.py
+++ b/kapitan/resources.py
@@ -346,7 +346,7 @@ def inventory_reclass(inventory_path, ignore_class_notfound=False):
     else:
         logger.debug("Inventory reclass: No config file found. Using reclass inventory config defaults")
 
-    # normalise relative nodes_uri and classes_uri paths and up
+    # normalise relative nodes_uri and classes_uri paths
     for uri in ("nodes_uri", "classes_uri"):
         reclass_config[uri] = os.path.normpath(os.path.join(inventory_path, reclass_config[uri]))
 

--- a/kapitan/resources.py
+++ b/kapitan/resources.py
@@ -341,7 +341,7 @@ def inventory_reclass(inventory_path, ignore_class_notfound=False):
                 reclass_config[key] = value
         else:
             logger.debug(
-                "{}: Invalid yaml or empty. Using reclass inventory config defaults".format(cfg_file)
+                "{}: Empty config file. Using reclass inventory config defaults".format(cfg_file)
             )
     else:
         logger.debug("Inventory reclass: No config file found. Using reclass inventory config defaults")


### PR DESCRIPTION
Fixes issue #969 

## Proposed Changes
- Refactor, fix and simplify the parsing / reading process of `reclass-config.yml` file
- It's unclear if the attribute `inventory_base_uri` is relative to its location (`inventory_path`) and if the subdirs `targets` (`nodes_uri`) and `classes` (`classes_uri`) should get their path from the `inventory_path` or the `inventory_base_uri`. I implemented it the way it was before ( --> `inventory_path`) but i would be nice to change that.

- We could add some documentation about this config file, especially with the new `compose-node-name` feature in #933 

--- 
### Contributed by  [<img src="https://www.nexenio.com/wp-content/uploads/2021/10/001-nexenio-logo-white-rgb@2x-e1636042495927.png" height="15em" />](https://www.nexenio.com)