### PR TITLE
Simplify input type Helm #977

### DIFF
--- a/docs/pages/input_types/helm.md
+++ b/docs/pages/input_types/helm.md
@@ -1,7 +1,7 @@
 # :kapitan-logo: **Input Type | Helm**
 
 This is a Python binding to `helm template` command for users with helm charts. This requires the `helm` binary to be installed locally.
-If you're using the kapitan docker image, then the `helm` binary is already instealled inside the image.
+If you're using the kapitan docker image, then the `helm` binary is already installed inside the image.
 
 Unlike other input types, Helm input types support the following additional parameters under `kapitan.compile`:
 
@@ -26,7 +26,8 @@ parameters:
         …
 ```
 
-Alternatively, instead of using a local `chart_path`, you can omit the `input_path` and specify the URL and chart name directly
+Alternatively, instead of using a local `chart_path`, you can omit the `input_path` and specify the URL and chart name directly. This way, nothing is cached locally and
+a request to the repo URL is made on every `kapitan compile` invocation.
 
 ```yaml
 parameters:

--- a/docs/pages/input_types/helm.md
+++ b/docs/pages/input_types/helm.md
@@ -1,6 +1,7 @@
 # :kapitan-logo: **Input Type | Helm**
 
-This is a Python binding to `helm template` command for users with helm charts. This does not require the helm executable, and the templates are rendered without the Tiller server.
+This is a Python binding to `helm template` command for users with helm charts. This requires the `helm` binary to be installed locally.
+If you're using the kapitan docker image, then the `helm` binary is already instealled inside the image.
 
 Unlike other input types, Helm input types support the following additional parameters under `kapitan.compile`:
 
@@ -25,11 +26,29 @@ parameters:
         …
 ```
 
+Alternatively, instead of using a local `chart_path`, you can omit the `input_path` and specify the URL and chart name directly
+
+```yaml
+parameters:
+  kapitan:
+    compile:
+    - output_path: <output_path>
+      input_type: helm
+      helm_params:
+        repo: https://charts.jetstack.io
+        chart_name: cert-manager
+        version: 1.1.0
+        …
+```
+
 `helm_values` is an object containing values specified that will override the default values in the input chart. This has exactly the same effect as specifying `--values custom_values.yml` for `helm template` command where `custom_values.yml` structure mirrors that of `helm_values`.
 
 `helm_values_files` is an array containing the paths to [helm values files](https://helm.sh/docs/chart_template_guide/values_files/) used as input for the chart. This has exactly the same effect as specifying `--file my_custom_values.yml` for the `helm template` command where `my_custom_values.yml` is a helm values file.
+
 If the same keys exist in `helm_values` and in multiple specified `helm_values_files`, the last indexed file in the `helm_values_files` will take precedence followed by the preceding `helm_values_files` and at the bottom the `helm_values` defined in teh compile block.
+
 There is an example in the tests. The `monitoring-dev`(kapitan/tests/test_resources/inventory/targets/monitoring-dev.yml) and `monitoring-prd`(kapitan/tests/test_resources/inventory/targets/monitoring-prd.yml) targets  both use the `monitoring`(tests/test_resources/inventory/classes/component/monitoring.yml) component.
+
 This component has helm chart input and takes a `common.yml` helm_values file which is "shared" by any target that uses the component and it also takes a dynamically defined file based on a kapitan variable defined in the target.
 
 `helm_path` can be use to provide the helm binary name or path.
@@ -55,7 +74,7 @@ Special flags:
 
 See the [helm doc](https://helm.sh/docs/helm/helm_template/) for further detail.
 
-#### Example
+## Example
 
 Let's use [nginx-ingress](https://github.com/helm/charts/tree/master/stable/nginx-ingress) helm chart as the input. Using [kapitan dependency manager](/external_dependencies.md), this chart can be fetched via a URL as listed in <https://helm.nginx.com/stable/index.yaml>.
 
@@ -107,18 +126,7 @@ $ grep "my-controller" compiled/nginx-from-chart/nginx-ingress/templates/control
         app: my-controller
 ```
 
-#### Building the binding from source
-
-Run
-
-```shell
-cd kapitan/inputs/helm
-./build.sh
-```
-
-This requires Go 1.14.
-
-#### Helm subcharts
+## Helm subcharts
 
 There is an [external dependency manager](/external_dependencies.md) of type `helm` which enables you to specify helm
 charts to download, including subcharts.

--- a/kapitan/inputs/base.py
+++ b/kapitan/inputs/base.py
@@ -40,6 +40,8 @@ class InputType(object):
 
         # expand any globbed paths, taking into account provided search paths
         input_paths = []
+        # not all comp_obj will have input_paths.
+        # Example: For input_type helm, the input_path is optional.
         for input_path in comp_obj.get("input_paths", []):
             globbed_paths = [glob.glob(os.path.join(path, input_path)) for path in self.search_paths]
             inputs = list(itertools.chain.from_iterable(globbed_paths))

--- a/kapitan/inputs/base.py
+++ b/kapitan/inputs/base.py
@@ -40,7 +40,7 @@ class InputType(object):
 
         # expand any globbed paths, taking into account provided search paths
         input_paths = []
-        for input_path in comp_obj["input_paths"]:
+        for input_path in comp_obj.get("input_paths", []):
             globbed_paths = [glob.glob(os.path.join(path, input_path)) for path in self.search_paths]
             inputs = list(itertools.chain.from_iterable(globbed_paths))
             # remove duplicate inputs
@@ -52,6 +52,11 @@ class InputType(object):
                     "search_paths: {}".format(input_path, ext_vars["target"], self.search_paths)
                 )
             input_paths.extend(inputs)
+
+        # Enable helm input type to compile without input_paths
+        # This is when we use helm CLI to download the chart
+        if input_type == "helm" and "input_paths" not in comp_obj:
+            self.compile_input_path("", comp_obj, ext_vars, **kwargs)
 
         for input_path in input_paths:
             self.compile_input_path(input_path, comp_obj, ext_vars, **kwargs)

--- a/kapitan/inputs/helm.py
+++ b/kapitan/inputs/helm.py
@@ -144,6 +144,7 @@ def render_chart(
     args = ["template"]
 
     name = helm_params.pop("name", None)
+    chart_name = helm_params.pop("chart_name", None)
     output_file = helm_params.pop("output_file", None)
 
     if helm_flags is None:
@@ -208,9 +209,15 @@ def render_chart(
     if "name_template" not in helm_flags:
         args.append(name or "--generate-name")
 
-    # uses absolute path to make sure helm interprets it as a
-    # local dir and not a chart_name that it should download.
-    args.append(chart_dir)
+    # if chart_name is specified then the last argument to helm_cli is the
+    # name of the chart we want to use. Otherwise it's the chart_dir that
+    # was previously downloaded as an external dependency
+    if chart_name:
+        args.append(chart_name)
+    else:
+        # uses absolute path to make sure helm interprets it as a
+        # local dir and not a chart_name that it should download.
+        args.append(chart_dir)
 
     # If output_path is '-', output is a string with rendered chart
     if output_path == "-":

--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -602,7 +602,6 @@ def valid_target_obj(target_obj, require_compile=True):
                         "suffix_remove": {"type": "boolean"},
                         "suffix_stripped": {"type": "string"},
                     },
-                    "required": ["input_type", "output_path"],
                     "minItems": 1,
                     "oneOf": [
                         {
@@ -610,8 +609,24 @@ def valid_target_obj(target_obj, require_compile=True):
                                 "input_type": {"enum": ["jsonnet", "kadet", "copy", "remove"]},
                                 "output_type": {"enum": ["yml", "yaml", "json", "plain", "toml"]},
                             },
+                            "required": ["input_type", "input_paths", "output_path"],
                         },
-                        {"properties": {"input_type": {"enum": ["jinja2", "helm", "external"]}}},
+                        {
+                            "properties": {"input_type": {"enum": ["jinja2", "helm", "external"]}},
+                            "required": ["input_type", "input_paths", "output_path"],
+                        },
+                        {
+                            "properties": {
+                                "helm_params": {
+                                    "properties": {
+                                        "chart_name": {"type": "string"},
+                                        "repo": {"type": "string"},
+                                    },
+                                    "required": ["chart_name", "repo"],
+                                },
+                            },
+                            "required": ["input_type", "helm_params", "output_path"],
+                        },
                     ],
                 },
             },

--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -602,7 +602,7 @@ def valid_target_obj(target_obj, require_compile=True):
                         "suffix_remove": {"type": "boolean"},
                         "suffix_stripped": {"type": "string"},
                     },
-                    "required": ["input_type", "input_paths", "output_path"],
+                    "required": ["input_type", "output_path"],
                     "minItems": 1,
                     "oneOf": [
                         {

--- a/tests/test_helm_input.py
+++ b/tests/test_helm_input.py
@@ -49,18 +49,12 @@ class HelmInputTest(unittest.TestCase):
         temp = tempfile.mkdtemp()
         sys.argv = ["kapitan", "compile", "--output-path", temp, "-t", "acs-engine-autoscaler"]
         main()
+        base_path = os.path.join(temp, "compiled", "acs-engine-autoscaler")
         self.assertTrue(
-            os.path.isfile(
-                os.path.join(
-                    temp,
-                    "compiled",
-                    "acs-engine-autoscaler",
-                    "acs-engine-autoscaler",
-                    "templates",
-                    "secrets.yaml",
-                )
-            )
+            os.path.isfile(os.path.join(base_path, "acs-engine-autoscaler", "templates", "secrets.yaml"))
         )
+
+        self.assertTrue(os.path.isfile(os.path.join(base_path, "expanded-cert-manager-chart.yaml")))
 
     def test_compile_subcharts(self):
         temp = tempfile.mkdtemp()

--- a/tests/test_resources/inventory/targets/acs-engine-autoscaler.yml
+++ b/tests/test_resources/inventory/targets/acs-engine-autoscaler.yml
@@ -8,3 +8,11 @@ parameters:
         input_type: helm
         input_paths:
           - charts/acs-engine-autoscaler
+
+      - output_path: .
+        input_type: helm
+        helm_params:
+          repo: https://charts.jetstack.io
+          chart_name: cert-manager
+          version: 1.1.0
+          output_file: expanded-cert-manager-chart.yaml


### PR DESCRIPTION
Fixes issue #977

## test

[this target file](https://github.com/kapicorp/kapitan/blob/a56d551/tests/test_resources/inventory/targets/acs-engine-autoscaler.yml#L6-L17) supports both formats of `input_type: helm`: 
* with a local chart 
* with URL and without input_path

As we can see in the output below, the `helm` binary is called in two different ways for each mode.

```
launching helm with arguments: ['template', '--include-crds', '--skip-tests', '--output-dir', '/tmp/tmp6318ts8t', '--generate-name', '/home/lburiola/git/github/kapitan/tests/test_resources/charts/acs-engine-autoscaler']

launching helm with arguments: ['template', '--include-crds', '--skip-tests', '--repo', 'https://charts.jetstack.io', '--version', '1.1.0', '--output-dir', '/tmp/tmp0iqle40w', '--generate-name', 'cert-manager']
```

FULL OUTPUT
```
$ ../../bin/kapitan compile -t acs-engine-autoscaler -v
2023-03-22 18:37:30,374 git.cmd      DEBUG    Popen(['git', 'version'], cwd=/home/lburiola/git/github/kapitan/tests/test_resources, universal_newlines=False, shell=None, istream=None)
2023-03-22 18:37:30,384 git.cmd      DEBUG    Popen(['git', 'version'], cwd=/home/lburiola/git/github/kapitan/tests/test_resources, universal_newlines=False, shell=None, istream=None)
2023-03-22 18:37:30,452 kapitan.cli  DEBUG    Running with args: Namespace(cache=False, cache_paths=[], compose_node_name=False, embed_refs=False, fetch=False, force=False, force_fetch=False, func=<function trigger_compile at 0x7feda5336b00>, ignore_version_check=False, indent=2, inventory_path='./inventory', jinja2_filters='lib/jinja2_filters.py', labels=[], name='compile', output_path='.', parallelism=4, prune=False, quiet=False, refs_path='./refs', reveal=False, schemas_path='./schemas', search_paths=['.', 'lib'], subparser_name='compile', targets=['acs-engine-autoscaler'], use_go_jsonnet=False, validate=False, verbose=True, yaml_dump_null_as_empty=False, yaml_multiline_string_style='double-quotes')
2023-03-22 18:37:30,543 kapitan.resources DEBUG    Using reclass inventory config defaults
2023-03-22 18:37:30,578 kapitan.utils DEBUG    hashable_lru_cache: True not serialiseable, using generic lru_cache instead
2023-03-22 18:37:30,614 kapitan.targets DEBUG    validating target name matches the name of yml file acs-engine-autoscaler
2023-03-22 18:37:30,614 kapitan.targets DEBUG    load_target_inventory: found valid kapitan target acs-engine-autoscaler
2023-03-22 18:37:30,614 kapitan.targets INFO     Rendered inventory (0.07s)
2023-03-22 18:37:30,873 git.cmd      DEBUG    Popen(['git', 'version'], cwd=/home/lburiola/git/github/kapitan/tests/test_resources, universal_newlines=False, shell=None, istream=None)
2023-03-22 18:37:30,879 git.cmd      DEBUG    Popen(['git', 'version'], cwd=/home/lburiola/git/github/kapitan/tests/test_resources, universal_newlines=False, shell=None, istream=None)
2023-03-22 18:37:31,271 kapitan.inputs.base DEBUG    Compiling /home/lburiola/git/github/kapitan/tests/test_resources/charts/acs-engine-autoscaler
2023-03-22 18:37:31,272 kapitan.helm_cli DEBUG    launching helm with arguments: ['template', '--include-crds', '--skip-tests', '--output-dir', '/tmp/tmp6318ts8t', '--generate-name', '/home/lburiola/git/github/kapitan/tests/test_resources/charts/acs-engine-autoscaler']
2023-03-22 18:37:31,363 kapitan.inputs.base DEBUG    Wrote /tmp/tmpom1otnvu.kapitan/compiled/acs-engine-autoscaler/./acs-engine-autoscaler/templates/secrets.yaml
2023-03-22 18:37:31,364 kapitan.inputs.helm DEBUG    Wrote file /tmp/tmp6318ts8t/acs-engine-autoscaler/templates/secrets.yaml to /tmp/tmpom1otnvu.kapitan/compiled/acs-engine-autoscaler/./acs-engine-autoscaler/templates/secrets.yaml
2023-03-22 18:37:31,439 kapitan.inputs.base DEBUG    Wrote /tmp/tmpom1otnvu.kapitan/compiled/acs-engine-autoscaler/./acs-engine-autoscaler/templates/deployment.yaml
2023-03-22 18:37:31,440 kapitan.inputs.helm DEBUG    Wrote file /tmp/tmp6318ts8t/acs-engine-autoscaler/templates/deployment.yaml to /tmp/tmpom1otnvu.kapitan/compiled/acs-engine-autoscaler/./acs-engine-autoscaler/templates/deployment.yaml
2023-03-22 18:37:31,440 kapitan.inputs.base DEBUG    Compiling 
2023-03-22 18:37:31,440 kapitan.helm_cli DEBUG    launching helm with arguments: ['template', '--include-crds', '--skip-tests', '--repo', 'https://charts.jetstack.io', '--version', '1.1.0', '--output-dir', '/tmp/tmp0iqle40w', '--generate-name', 'cert-manager']
2023-03-22 18:37:33,127 kapitan.inputs.base DEBUG    Wrote /tmp/tmpom1otnvu.kapitan/compiled/acs-engine-autoscaler/./cert-manager/templates/cainjector-serviceaccount.yaml
2023-03-22 18:37:33,127 kapitan.inputs.helm DEBUG    Wrote file /tmp/tmp0iqle40w/cert-manager/templates/cainjector-serviceaccount.yaml to /tmp/tmpom1otnvu.kapitan/compiled/acs-engine-autoscaler/./cert-manager/templates/cainjector-serviceaccount.yaml
2023-03-22 18:37:33,130 kapitan.inputs.base DEBUG    Wrote /tmp/tmpom1otnvu.kapitan/compiled/acs-engine-autoscaler/./cert-manager/templates/serviceaccount.yaml
2023-03-22 18:37:33,130 kapitan.inputs.helm DEBUG    Wrote file /tmp/tmp0iqle40w/cert-manager/templates/serviceaccount.yaml to /tmp/tmpom1otnvu.kapitan/compiled/acs-engine-autoscaler/./cert-manager/templates/serviceaccount.yaml
2023-03-22 18:37:33,133 kapitan.inputs.base DEBUG    Wrote /tmp/tmpom1otnvu.kapitan/compiled/acs-engine-autoscaler/./cert-manager/templates/webhook-serviceaccount.yaml
2023-03-22 18:37:33,133 kapitan.inputs.helm DEBUG    Wrote file /tmp/tmp0iqle40w/cert-manager/templates/webhook-serviceaccount.yaml to /tmp/tmpom1otnvu.kapitan/compiled/acs-engine-autoscaler/./cert-manager/templates/webhook-serviceaccount.yaml
2023-03-22 18:37:33,152 kapitan.inputs.base DEBUG    Wrote /tmp/tmpom1otnvu.kapitan/compiled/acs-engine-autoscaler/./cert-manager/templates/cainjector-rbac.yaml
2023-03-22 18:37:33,152 kapitan.inputs.helm DEBUG    Wrote file /tmp/tmp0iqle40w/cert-manager/templates/cainjector-rbac.yaml to /tmp/tmpom1otnvu.kapitan/compiled/acs-engine-autoscaler/./cert-manager/templates/cainjector-rbac.yaml
2023-03-22 18:37:33,227 kapitan.inputs.base DEBUG    Wrote /tmp/tmpom1otnvu.kapitan/compiled/acs-engine-autoscaler/./cert-manager/templates/rbac.yaml
2023-03-22 18:37:33,227 kapitan.inputs.helm DEBUG    Wrote file /tmp/tmp0iqle40w/cert-manager/templates/rbac.yaml to /tmp/tmpom1otnvu.kapitan/compiled/acs-engine-autoscaler/./cert-manager/templates/rbac.yaml
2023-03-22 18:37:33,235 kapitan.inputs.base DEBUG    Wrote /tmp/tmpom1otnvu.kapitan/compiled/acs-engine-autoscaler/./cert-manager/templates/webhook-rbac.yaml
2023-03-22 18:37:33,235 kapitan.inputs.helm DEBUG    Wrote file /tmp/tmp0iqle40w/cert-manager/templates/webhook-rbac.yaml to /tmp/tmpom1otnvu.kapitan/compiled/acs-engine-autoscaler/./cert-manager/templates/webhook-rbac.yaml
2023-03-22 18:37:33,239 kapitan.inputs.base DEBUG    Wrote /tmp/tmpom1otnvu.kapitan/compiled/acs-engine-autoscaler/./cert-manager/templates/service.yaml
2023-03-22 18:37:33,239 kapitan.inputs.helm DEBUG    Wrote file /tmp/tmp0iqle40w/cert-manager/templates/service.yaml to /tmp/tmpom1otnvu.kapitan/compiled/acs-engine-autoscaler/./cert-manager/templates/service.yaml
2023-03-22 18:37:33,243 kapitan.inputs.base DEBUG    Wrote /tmp/tmpom1otnvu.kapitan/compiled/acs-engine-autoscaler/./cert-manager/templates/webhook-service.yaml
2023-03-22 18:37:33,243 kapitan.inputs.helm DEBUG    Wrote file /tmp/tmp0iqle40w/cert-manager/templates/webhook-service.yaml to /tmp/tmpom1otnvu.kapitan/compiled/acs-engine-autoscaler/./cert-manager/templates/webhook-service.yaml
2023-03-22 18:37:33,250 kapitan.inputs.base DEBUG    Wrote /tmp/tmpom1otnvu.kapitan/compiled/acs-engine-autoscaler/./cert-manager/templates/cainjector-deployment.yaml
2023-03-22 18:37:33,250 kapitan.inputs.helm DEBUG    Wrote file /tmp/tmp0iqle40w/cert-manager/templates/cainjector-deployment.yaml to /tmp/tmpom1otnvu.kapitan/compiled/acs-engine-autoscaler/./cert-manager/templates/cainjector-deployment.yaml
2023-03-22 18:37:33,259 kapitan.inputs.base DEBUG    Wrote /tmp/tmpom1otnvu.kapitan/compiled/acs-engine-autoscaler/./cert-manager/templates/deployment.yaml
2023-03-22 18:37:33,259 kapitan.inputs.helm DEBUG    Wrote file /tmp/tmp0iqle40w/cert-manager/templates/deployment.yaml to /tmp/tmpom1otnvu.kapitan/compiled/acs-engine-autoscaler/./cert-manager/templates/deployment.yaml
2023-03-22 18:37:33,270 kapitan.inputs.base DEBUG    Wrote /tmp/tmpom1otnvu.kapitan/compiled/acs-engine-autoscaler/./cert-manager/templates/webhook-deployment.yaml
2023-03-22 18:37:33,270 kapitan.inputs.helm DEBUG    Wrote file /tmp/tmp0iqle40w/cert-manager/templates/webhook-deployment.yaml to /tmp/tmpom1otnvu.kapitan/compiled/acs-engine-autoscaler/./cert-manager/templates/webhook-deployment.yaml
2023-03-22 18:37:33,276 kapitan.inputs.base DEBUG    Wrote /tmp/tmpom1otnvu.kapitan/compiled/acs-engine-autoscaler/./cert-manager/templates/webhook-mutating-webhook.yaml
2023-03-22 18:37:33,276 kapitan.inputs.helm DEBUG    Wrote file /tmp/tmp0iqle40w/cert-manager/templates/webhook-mutating-webhook.yaml to /tmp/tmpom1otnvu.kapitan/compiled/acs-engine-autoscaler/./cert-manager/templates/webhook-mutating-webhook.yaml
2023-03-22 18:37:33,283 kapitan.inputs.base DEBUG    Wrote /tmp/tmpom1otnvu.kapitan/compiled/acs-engine-autoscaler/./cert-manager/templates/webhook-validating-webhook.yaml
2023-03-22 18:37:33,283 kapitan.inputs.helm DEBUG    Wrote file /tmp/tmp0iqle40w/cert-manager/templates/webhook-validating-webhook.yaml to /tmp/tmpom1otnvu.kapitan/compiled/acs-engine-autoscaler/./cert-manager/templates/webhook-validating-webhook.yaml
2023-03-22 18:37:33,283 kapitan.targets INFO     Compiled acs-engine-autoscaler (2.01s)
2023-03-22 18:37:33,291 kapitan.targets DEBUG    Copied /tmp/tmpom1otnvu.kapitan/compiled/acs-engine-autoscaler into ./compiled/acs-engine-autoscaler
2023-03-22 18:37:33,581 kapitan.targets DEBUG    Removed /tmp/tmpom1otnvu.kapitan
```