### PR TITLE
Fix typo in kadet prune input handling

### DIFF
--- a/kapitan/inputs/base.py
+++ b/kapitan/inputs/base.py
@@ -64,7 +64,7 @@ class InputType(object):
         target_name = ext_vars["target"]
         output_path = comp_obj["output_path"]
         output_type = comp_obj.get("output_type", self.default_output_type())
-        prune_input = comp_obj.get("prune", kwargs.get("prune", False))
+        prune_output = comp_obj.get("prune", kwargs.get("prune", False))
 
         logger.debug("Compiling %s", input_path)
         try:
@@ -78,7 +78,7 @@ class InputType(object):
                 ext_vars,
                 output=output_type,
                 target_name=target_name,
-                prune_input=prune_input,
+                prune_output=prune_output,
                 **kwargs,
             )
         except KapitanError as e:

--- a/kapitan/inputs/jsonnet.py
+++ b/kapitan/inputs/jsonnet.py
@@ -97,7 +97,7 @@ class Jsonnet(InputType):
         output_obj = json.loads(json_output)
 
         output = kwargs.get("output", "yaml")
-        prune = kwargs.get("prune_input", False)
+        prune = kwargs.get("prune_output", False)
         reveal = kwargs.get("reveal", False)
         target_name = kwargs.get("target_name", None)
         indent = kwargs.get("indent", 2)

--- a/kapitan/inputs/kadet.py
+++ b/kapitan/inputs/kadet.py
@@ -92,13 +92,13 @@ class Kadet(InputType):
         ext_vars is not used in Kadet
         kwargs:
             output: default 'yaml', accepts 'json'
-            prune: default False
+            prune_output: default False
             reveal: default False, set to reveal refs on compile
             target_name: default None, set to current target being compiled
             indent: default 2
         """
         output = kwargs.get("output", "yaml")
-        prune = kwargs.get("prune", False)
+        prune_output = kwargs.get("prune_output", False)
         reveal = kwargs.get("reveal", False)
         target_name = kwargs.get("target_name", None)
         # inventory_path = kwargs.get("inventory_path", None)
@@ -135,7 +135,7 @@ class Kadet(InputType):
             raise CompileError(f"Could not load Kadet module: {spec.name[16:]}")
 
         output_obj = _to_dict(output_obj)
-        if prune:
+        if prune_output:
             output_obj = prune_empty(output_obj)
 
         # Return None if output_obj has no output


### PR DESCRIPTION
Fixes issue with kadet pruning

```
  kapitan:
    compile:
      - output_path: manifests
        input_type: kadet
        output_type: yml
        prune: false   <------- honour this prune to override the default
  ```

## Proposed Changes

- a typo was preventing "prune" to be read from the input definition ([see](https://github.com/kapicorp/kapitan/blob/f5fd147682e7e47943e2330942d7610960fec642/kapitan/inputs/base.py#LL81C23-L81C23)) 