### PR TITLE
fix(gh-actions): Avoid running pipeline twice for pull-requests

### DIFF
--- a/.github/workflows/python-black.yml
+++ b/.github/workflows/python-black.yml
@@ -1,6 +1,10 @@
 ---
 name: Python Lint
-on: [push, pull_request]
+on: 
+  push:
+    branches:
+      - master
+  pull_request:
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,8 @@ on:
   push:
     paths-ignore:
       - 'docs/**'
+    branches:
+      - master
   pull_request:
     paths-ignore:
       - 'docs/**'


### PR DESCRIPTION
## Proposed Changes
- github actions don't run twice in a pull-request, because of triggers `push` and `pull-request`

@kapicorp/kapicorp What are your thoughts on running the tests in a os matrix, like for Windows, MacOS and Linux?

--- 
### Contributed by  [<img src="https://www.nexenio.com/wp-content/uploads/2021/10/001-nexenio-logo-white-rgb@2x-e1636042495927.png" height="15em" />](https://www.nexenio.com)