### PR TITLE
chore(gh-actions): Add housekeeping action to close stale issues

### DIFF
--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -1,0 +1,17 @@
+name: 'Housekeeping'
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity. Please reopen the issue, if this happened accidently.'
+          days-before-issue-stale: 90
+          day-before-pr-stale: -1
+          days-before-close: 7
+          days-before-pr-close: -1


### PR DESCRIPTION
Fixes #902

## Proposed Changes
- Added a github-action that marks issues as stale and closes them, if they not get any activity.
- Parameters:
  - schedule: daily at 00:00
  - mark issues as stale: 90 days
  - close stale issues: 7 days
  - mark pr's as stale/ close pr: never

--- 
### Contributed by  [<img src="https://www.nexenio.com/wp-content/uploads/2021/10/001-nexenio-logo-white-rgb@2x-e1636042495927.png" height="15em" />](https://www.nexenio.com)