### PR TITLE
fix(tests): remove merge annotations from #993

### DIFF
--- a/kapitan/inputs/kadet.py
+++ b/kapitan/inputs/kadet.py
@@ -92,21 +92,13 @@ class Kadet(InputType):
         ext_vars is not used in Kadet
         kwargs:
             output: default 'yaml', accepts 'json'
-<<<<<<< HEAD
-            prune_output: default False
-=======
             prune_input: default False
->>>>>>> dcd110c (Fix typo in kadet prune input handling)
             reveal: default False, set to reveal refs on compile
             target_name: default None, set to current target being compiled
             indent: default 2
         """
         output = kwargs.get("output", "yaml")
-<<<<<<< HEAD
-        prune_output = kwargs.get("prune_output", False)
-=======
         prune_input = kwargs.get("prune_input", False)
->>>>>>> dcd110c (Fix typo in kadet prune input handling)
         reveal = kwargs.get("reveal", False)
         target_name = kwargs.get("target_name", None)
         # inventory_path = kwargs.get("inventory_path", None)
@@ -143,11 +135,7 @@ class Kadet(InputType):
             raise CompileError(f"Could not load Kadet module: {spec.name[16:]}")
 
         output_obj = _to_dict(output_obj)
-<<<<<<< HEAD
-        if prune_output:
-=======
         if prune_input:
->>>>>>> dcd110c (Fix typo in kadet prune input handling)
             output_obj = prune_empty(output_obj)
 
         # Return None if output_obj has no output

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,7 +87,7 @@ nav:
   - Documentation:
       - Overview: pages/kapitan_overview.md
       - Inventory:
-        - Introduction: /inventory/introduction.md
+        - Introduction: pages/inventory/introduction.md
         - Targets: pages/inventory/targets.md
         - Classes: pages/inventory/classes.md
         - Parameters Interpolation: pages/inventory/parameters_interpolation.md


### PR DESCRIPTION
## Proposed Changes
- Fix the tests, which were failing because of merge information introduced by #993
- I noticed that [https://kapitan.dev/inventory/introduction.md](https://kapitan.dev/inventory/introduction.md) gives an 404 error, so I updated the path in `mkdocs.yaml`

--- 
### Contributed by  [<img src="https://www.nexenio.com/wp-content/uploads/2021/10/001-nexenio-logo-white-rgb@2x-e1636042495927.png" height="15em" />](https://www.nexenio.com)