### PR TITLE
Improve remote fetch logging

### DIFF
--- a/kapitan/remoteinventory/fetch.py
+++ b/kapitan/remoteinventory/fetch.py
@@ -54,7 +54,7 @@ def fetch_inventories(inventory_path, target_objs, save_dir, force, pool):
 
                 if output_path in inv_output_path[source_uri]:
                     # if the output_path is duplicated for the same source_uri
-                    logger.warning("Skipping duplicate output path for uri %s", source_uri)
+                    logger.debug("Skipping duplicate output path for uri %s", source_uri)
                     continue
                 else:
                     inv_output_path[source_uri].add(output_path)

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -589,7 +589,7 @@ def safe_copy_file(src, dst):
         dir = os.path.dirname(dst)
 
     if os.path.isfile(dst):
-        logger.warning("Not updating %s (file already exists)", dst)
+        logger.debug("Not updating %s (file already exists)", dst)
         return (dst, 0)
     _copy_file_contents(src, dst)
     logger.debug("Copied %s to %s", src, dir)
@@ -627,7 +627,8 @@ def safe_copy_tree(src, dst):
             outputs.extend(safe_copy_tree(src_name, dst_name))
 
         else:
-            safe_copy_file(src_name, dst_name)
-            outputs.append(dst_name)
+            _, value = safe_copy_file(src_name, dst_name)
+            if value:
+                outputs.append(dst_name)
 
     return outputs


### PR DESCRIPTION
Fixes issue #

Improve logging for remote fetch to make it less verbose and noisy. Aim is to allow for it to be enabled by default.

## Proposed Changes

- fix logging 
- improve documentation

## Example

### `.kapitan` enables fetch
```
compile:
 fetch: true
 ```

### remove generators
```
$ rm -fr components/generators/kubernetes/
```

### `kapitan compile` automatically installs generators
```
$ kap compile
creating components/generators/kubernetes
Dependency https://github.com/kapicorp/kapitan-reference.git: saved to components/generators/kubernetes
Rendered inventory (3.76s)
Compiled pritunl (0.10s)
Compiled vault (0.09s)
Compiled examples (0.13s)
Compiled gke-pvm-killer (0.05s)
Compiled mysql (0.05s)
Compiled postgres-proxy (0.06s)
Compiled echo-server (0.06s)
Compiled sock-shop (0.16s)
Compiled global (0.04s)
Compiled tutorial (0.07s)
Compiled guestbook-argocd (0.05s)
Compiled kapicorp-project-123 (0.04s)
Compiled kapicorp-demo-march (0.05s)
Compiled kapicorp-terraform-admin (0.04s)
Compiled tesoro (0.12s)
Compiled dev-sockshop (0.20s)
Compiled prod-sockshop (0.17s)
Compiled argocd (0.80s)
Compiled github-actions (4.66s)
```
