### PR TITLE
fix(tests): set vault image to new `hashicorp/vault` tag

### DIFF
--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -30,7 +30,7 @@ env = {
 }
 
 vault_container = client.containers.run(
-    image="vault",
+    image="hashicorp/vault",
     cap_add=["IPC_LOCK"],
     ports={"8200": "8200"},
     environment=env,

--- a/tests/test_vault_transit.py
+++ b/tests/test_vault_transit.py
@@ -37,7 +37,7 @@ env = {
 }
 
 vault_container = client.containers.run(
-    image="vault",
+    image="hashicorp/vault",
     cap_add=["IPC_LOCK"],
     ports={8200: DOCKER_PORT},
     environment=env,


### PR DESCRIPTION
Fixes tests

## Proposed Changes
- Hashicorp changed their tags for the `vault` image to `hashicorp/vault`

--- 
### Contributed by  [<img src="https://www.nexenio.com/wp-content/uploads/2021/10/001-nexenio-logo-white-rgb@2x-e1636042495927.png" height="15em" />](https://www.nexenio.com)
