### PR TITLE
chore: bump Dockerfile golang version to 1.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN python -m venv $VIRTUAL_ENV \
     && pip install --upgrade pip yq wheel poetry==$POETRY_VERSION
 
 # Install Go (for go-jsonnet)
-RUN curl -fsSL -o go.tar.gz https://go.dev/dl/go1.17.3.linux-${TARGETARCH}.tar.gz \
+RUN curl -fsSL -o go.tar.gz https://go.dev/dl/go1.20.8.linux-${TARGETARCH}.tar.gz \
     && tar -C /usr/local -xzf go.tar.gz \
     && rm go.tar.gz
 


### PR DESCRIPTION
## Proposed Changes

As specified by the golang [release policy](https://go.dev/doc/devel/release#policy), "each major go release is supported until there are two newer major releases", which mean that the oldest supported version is currently go 1.20. 

I propose we upgrade the golang version used in the Dockerfile to build go-jsonnet to go 1.20.7 (but we could switch to go 1.21.0 as well if preferred).