### PR TITLE
speed up python tests by running them only once

### DIFF
--- a/.github/workflows/test-build-publish.yml
+++ b/.github/workflows/test-build-publish.yml
@@ -72,7 +72,8 @@ jobs:
           pip3 install coverage black
       - name: Run tests
         run: |-
-          make test && make test_coverage
+          # includes make test
+          make test_coverage 
 
   build:
     name: build ${{ matrix.platform }} image
@@ -112,6 +113,7 @@ jobs:
       - name: Test Kapitan for ${{ matrix.platform }}
         run: |
           docker run -t --rm local-test-${{ matrix.platform }} --version
+
 
   publish:
     name: publish platform images


### PR DESCRIPTION
## Proposed Changes

- runs tests only once (coverage already runs the tests)
-
-
