### PR TITLE
fix(gh-actions): only publish when name is given

### DIFF
--- a/.github/workflows/test-build-publish.yml
+++ b/.github/workflows/test-build-publish.yml
@@ -226,6 +226,9 @@ jobs:
             type=semver,pattern={{major}}
             
       - uses: int128/docker-manifest-create-action@v1
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME}}
+        if: env.DOCKERHUB_USERNAME != null
         with:
           tags: ${{ steps.meta.outputs.tags }}
           builder: buildx


### PR DESCRIPTION
## Proposed Changes

* Fixes the following issue: 
On default-branches (or test/*) on forks with no docker-username, the docker buildx command fails, because no name is given and the images are named `/kapitan[...]`, which is not allowed and throws `invalid reference format`. Now if no name is given, the command will be skipped.

[Action run on nexenio-fork for reference](https://github.com/neXenio/kapitan/actions/runs/6378617783/job/17310272281)