### PR TITLE
fix: set yaml line width to infinity

### DIFF
--- a/kapitan/inputs/base.py
+++ b/kapitan/inputs/base.py
@@ -11,9 +11,10 @@ import json
 import logging
 import os
 from collections.abc import Mapping
+from math import inf
 
-import yaml
 import toml
+import yaml
 
 from kapitan.errors import CompileError, KapitanError
 from kapitan.refs.base import Revealer
@@ -136,6 +137,7 @@ class CompilingFile(object):
                     indent=indent,
                     Dumper=PrettyDumper,
                     default_flow_style=False,
+                    width=inf,
                 )
             else:
                 yaml.dump_all(
@@ -144,6 +146,7 @@ class CompilingFile(object):
                     indent=indent,
                     Dumper=PrettyDumper,
                     default_flow_style=False,
+                    width=inf,
                 )
 
             logger.debug("Wrote %s", self.fp.name)


### PR DESCRIPTION
## Proposed Changes

* sets the yaml dump width to `inf`
* this fixes an issue, that yaml uses `80` characters by default until an automatic linebreak gets inserted. For long expressions this is not suitable.


This may be a breaking change, but no one should really depend on automatic line breaks at the limit of 80 characters.
I would offer, to make it configurable via a flag, if it is necessary.

[stackoverflow-solution for reference](https://stackoverflow.com/questions/18514205/how-to-prevent-yaml-to-dump-long-line-without-new-line)
