### PR TITLE
docs: fix wrong indentation for backticks at help output

### DIFF
--- a/docs/pages/commands/kapitan_compile.md
+++ b/docs/pages/commands/kapitan_compile.md
@@ -213,4 +213,4 @@ The `--embed-refs` flags tells **Kapitan** to embed these references on compile,
                                 targets to compile, default is all
           --labels [key=value ...], -l [key=value ...]
                                 compile targets matching the labels, default is all
-          ```
+        ```


### PR DESCRIPTION
Fixes #1093

## Proposed Changes

* fix wrong indentation for backticks at help output

## Docs and Tests

* Tested locally