### PR TITLE
Set logger error

### DIFF
--- a/kapitan/__init__.py
+++ b/kapitan/__init__.py
@@ -7,32 +7,35 @@
 
 import os
 import sys
-import logging
 
-
-def setup_logging(name=None, level=logging.INFO, force=False):
-    "setup logging and deal with logging behaviours in MacOS python 3.8 and below"
-    # default opts
-    kwopts = {"format": "%(message)s", "level": level}
-
-    if level == logging.DEBUG:
-        kwopts["format"] = "%(asctime)s %(name)-12s %(levelname)-8s %(message)s"
-
-    if sys.version_info >= (3, 8) and force:
-        kwopts["force"] = True
-
-    logging.basicConfig(**kwopts)
-
-    if sys.version_info < (3, 8) and force:
-        logging.getLogger(name).setLevel(level)
-
-
-# XXX in MacOS, updating logging level in __main__ doesn't work for python3.8+
-# XXX this is a hack that seems to work
-if "-v" in sys.argv or "--verbose" in sys.argv:
-    setup_logging(level=logging.DEBUG)
-else:
-    setup_logging()
+# this dict is used to confgiure in various places, such as setup spawned processes
+logging_config = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "brief": {"format": "%(message)s"},
+        "extended": {"format": "%(asctime)s %(name)-12s %(levelname)-8s %(message)s"},
+    },
+    "handlers": {
+        "brief": {
+            "class": "logging.StreamHandler",
+            "level": "INFO",
+            "formatter": "brief",
+            "stream": "ext://sys.stdout",
+        },
+        "extended": {
+            "class": "logging.StreamHandler",
+            "level": "INFO",
+            "formatter": "extended",
+            "stream": "ext://sys.stdout",
+        },
+    },
+    "loggers": {
+        "kapitan": {"level": "INFO", "propagate": True},
+        "reclass": {"level": "INFO", "propagate": True},
+    },
+    "root": {"level": "ERROR", "handlers": ["brief"]},
+}
 
 # Adding reclass to PYTHONPATH
 sys.path.insert(0, os.path.dirname(__file__) + "/reclass")

--- a/kapitan/__init__.py
+++ b/kapitan/__init__.py
@@ -8,7 +8,7 @@
 import os
 import sys
 
-# this dict is used to confgiure in various places, such as setup spawned processes
+# this dict is used to confgiure the python logging in various places, such as setup spawned processes
 logging_config = {
     "version": 1,
     "disable_existing_loggers": False,

--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -652,7 +652,6 @@ def setup_logging(args=None):
     if hasattr(args, "logging_config") and args.logging_config != "":
         with open(args.logging_config, "r", encoding="ascii") as f:
             logging_config.update(yaml.safe_load(f))
-        logging.config.fileConfig(args.logging_config)
     else:
         if hasattr(args, "verbose") and args.verbose:
             set_kapitan_loggers("DEBUG", "extended")

--- a/kapitan/remoteinventory/fetch.py
+++ b/kapitan/remoteinventory/fetch.py
@@ -4,7 +4,7 @@ import os
 from collections import defaultdict
 from functools import partial
 
-from kapitan import cached
+from kapitan import cached, logging_config
 from kapitan.dependency_manager.base import fetch_git_dependency, fetch_http_dependency
 from kapitan.utils import normalise_join_path
 
@@ -69,7 +69,13 @@ def fetch_inventories(inventory_path, target_objs, save_dir, force, pool):
             logger.debug("Target object %s has no inventory key", target_obj["vars"]["target"])
             continue
 
-    git_worker = partial(fetch_git_dependency, save_dir=save_dir, force=force, item_type="Inventory")
+    git_worker = partial(
+        fetch_git_dependency,
+        save_dir=save_dir,
+        force=force,
+        item_type="Inventory",
+        logging_config_dict=logging_config,
+    )
     http_worker = partial(fetch_http_dependency, save_dir=save_dir, force=force, item_type="Inventory")
     [p.get() for p in pool.imap_unordered(git_worker, git_inventories.items()) if p]
     [p.get() for p in pool.imap_unordered(http_worker, http_inventories.items()) if p]

--- a/tests/test_kubernetes_validator.py
+++ b/tests/test_kubernetes_validator.py
@@ -95,7 +95,9 @@ class KubernetesValidatorTest(unittest.TestCase):
                 # copy back the original file
                 copyfile(copied_file, original_file)
                 os.remove(copied_file)
-        self.assertTrue(captured_out.getvalue().find("invalid '{}' manifest".format(wrong_manifest_kind)) != -1)
+        self.assertTrue(
+            captured_out.getvalue().find("invalid '{}' manifest".format(wrong_manifest_kind)) != -1
+        )
 
     def test_validate_after_compile(self):
         sys.argv = [


### PR DESCRIPTION
Fixes kapitan compile shows output from like: 

creating ... 
copying ... -> ...

It comes from: https://github.com/pypa/distutils/blob/main/distutils/file_util.py#L135

## Proposed Changes

* setup all loggers on error
* keep kapitan and reclass on info as output such as Rendered inventory and Compiled target are emitted through it.
* kapitan inventory and compile has a paramter --logging-config that allows a yaml file.

## Docs and Tests

* [] Tests added
* [ ] Updated documentation