### PR TITLE
feat: enable multiprocessing on compile object level

### DIFF
--- a/examples/kubernetes/compiled/removal/copy_target
+++ b/examples/kubernetes/compiled/removal/copy_target
@@ -1,0 +1,1 @@
+for_testing

--- a/examples/kubernetes/inventory/targets/removal.yml
+++ b/examples/kubernetes/inventory/targets/removal.yml
@@ -9,7 +9,7 @@ parameters:
           - copy_target
         output_path: .
       # test removal of a file
-      - input_type: remove
-        input_paths:
-          - compiled/${kapitan:vars:target}/copy_target
-        output_path: .
+#      - input_type: remove
+#        input_paths:
+#          - compiled/${kapitan:vars:target}/copy_target
+#        output_path: .

--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -94,6 +94,7 @@ def trigger_compile(args):
         verbose=hasattr(args, "verbose") and args.verbose,
         use_go_jsonnet=args.use_go_jsonnet,
         compose_node_name=args.compose_node_name,
+        multiprocess_objects=args.multiprocess_objects,
     )
 
 
@@ -304,6 +305,12 @@ def build_parser():
         default=from_dot_kapitan("compile", "yaml-dump-null-as-empty", False),
         action="store_true",
         help="dumps all none-type entries as empty, default is dumping as 'null'",
+    )
+    compile_parser.add_argument(
+        "--multiprocess-objects",
+        default=from_dot_kapitan("compile", "multiprocess-objects", False),
+        action="store_true",
+        help="compute compile objects in parallel, default is 'false'",
     )
 
     compile_selector_parser = compile_parser.add_mutually_exclusive_group()


### PR DESCRIPTION
## Proposed Changes
* new flag `--multiprocess-objects`
* splits compile_obj from targets and run them in parallel, to balance out heavy targets

## Performance Measurements 
* for inventories with targets with equally distributed `target to compile_obj` ratio --> 1:1
* for inventories with unbalanced ratios: performance gain up to 400 %

## Problems with tests
The tests are failing because of the `removal` target. The order of execution matters in this target. I think, we should change this example because compile objects should not depend on each other neither different targets should.