### PR TITLE
[WIP] Explicitly defining permissions for files in the compiled directory

### DIFF
--- a/kapitan/inputs/base.py
+++ b/kapitan/inputs/base.py
@@ -82,13 +82,13 @@ class InputType(object):
                 prune_output=prune_output,
                 **kwargs,
             )
-            if (permissions is not None):
+            if permissions is not None:
                 for perm in permissions:
-                    pattern = perm.get('pattern', None)
-                    mode = perm.get('mode', None)
-                    assert(pattern is not None and mode is not None)
+                    pattern = perm.get("pattern", None)
+                    mode = perm.get("mode", None)
+                    assert pattern is not None and mode is not None
                     logger.debug("Find files in %s, pattern %s, file mode %s", _compile_path, pattern, mode)
-                    for item in glob.glob(_compile_path + "/" + pattern, recursive = True):
+                    for item in glob.glob(_compile_path + "/" + pattern, recursive=True):
                         logger.debug("Set permission for file %s, mode %s", item, mode)
                         os.chmod(item, mode)
 

--- a/kapitan/inputs/base.py
+++ b/kapitan/inputs/base.py
@@ -65,6 +65,7 @@ class InputType(object):
         output_path = comp_obj["output_path"]
         output_type = comp_obj.get("output_type", self.default_output_type())
         prune_output = comp_obj.get("prune", kwargs.get("prune", False))
+        permissions = comp_obj.get("permissions", None)
 
         logger.debug("Compiling %s", input_path)
         try:
@@ -81,6 +82,16 @@ class InputType(object):
                 prune_output=prune_output,
                 **kwargs,
             )
+            if (permissions is not None):
+                for perm in permissions:
+                    pattern = perm.get('pattern', None)
+                    mode = perm.get('mode', None)
+                    assert(pattern is not None and mode is not None)
+                    logger.debug("Find files in %s, pattern %s, file mode %s", _compile_path, pattern, mode)
+                    for item in glob.glob(_compile_path + "/" + pattern, recursive = True):
+                        logger.debug("Set permission for file %s, mode %s", item, mode)
+                        os.chmod(item, mode)
+
         except KapitanError as e:
             raise CompileError("{}\nCompile error: failed to compile target: {}".format(e, target_name))
 

--- a/kapitan/inputs/templates/inventory/classes/my_component.yml
+++ b/kapitan/inputs/templates/inventory/classes/my_component.yml
@@ -15,6 +15,9 @@ parameters:
         input_type: jinja2
         input_paths:
           - templates/scripts
+        permissions:
+          - pattern: my_script.sh
+            mode: 0o700
 
       - output_path: .
         output_type: yaml


### PR DESCRIPTION
Fixes #506 

## Proposed Changes

Include permissions in the input section to explicitly define access rights for files in compiled directories

Example:
```yaml
      kapitan:
        compile:
          - input_paths:
              - templates/scripts
            output_path: scripts
            input_type: jinja2
            permissions:
              -
                # https://docs.python.org/3/library/glob.html
                # recursive search
                pattern: my_script
                # https://docs.python.org/3/library/os.html?#os.chmod
                mode: 0o700
 ```
    
How it works:

```shell
$ kapitan init
$ kapitan compile
$ ls -ltr compiled/my_target/scripts/my_script.sh
 -rwx------ 1 kapitan kapitan 99 Jan 18 14:59 compiled/my_target/scripts/my_script.sh
$ compiled/my_target/scripts/my_script.sh
Running for target my_target
compiled/my_target/scripts
```

This PR is in a very early stage. If this approach for setting file permissions is acceptable, I will continue to work on it; otherwise, let's discuss alternatives.

## Docs and Tests

* [ ] Tests added
* [ ] Updated documentation

