### PR TITLE
Revert "chore: bump int128/docker-manifest-create-action from 1 to 2"

### DIFF
--- a/.github/workflows/test-build-publish.yml
+++ b/.github/workflows/test-build-publish.yml
@@ -227,7 +227,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             
-      - uses: int128/docker-manifest-create-action@v2
+      - uses: int128/docker-manifest-create-action@v1
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME}}
         if: env.DOCKERHUB_USERNAME != null


### PR DESCRIPTION
Reverts kapicorp/kapitan#1107

`v2` does not support `suffixes` anymore and goes with a new `sources` approach, where you would define the links to the image via digest. Wit hour current matrix strategy its hard to retrieve the digest per image / per platform. So let's rollback for now!

Guide to migrate by action owner:

### Migration from V1 to V2

This action no longer supports the `suffixes` input.
You need to set an image URI with a digest or tag.
If you use docker/build-push-action, you can construct an image URI from the outputs as follows:

```yaml
- uses: docker/build-push-action@v5
  id: build-amd64
  with: # ...omit...
- uses: docker/build-push-action@v5
  id: build-arm64
  with: # ...omit...

- uses: int128/docker-manifest-create-action@v2
  with:
    tags: ghcr.io/${{ github.repository }}:main
    sources: |
      ghcr.io/${{ github.repository }}@${{ steps.build-amd64.outputs.digest }}
      ghcr.io/${{ github.repository }}@${{ steps.build-arm64.outputs.digest }}
```