### PR TITLE
Simplify populating each target's classes list in `ReclassInventory`

### DIFF
--- a/kapitan/inventory/inv_reclass.py
+++ b/kapitan/inventory/inv_reclass.py
@@ -43,10 +43,7 @@ class ReclassInventory(Inventory):
             # store parameters and classes
             for target_name, rendered_target in rendered_inventory["nodes"].items():
                 self.targets[target_name].parameters = rendered_target["parameters"]
-
-            for class_name, referenced_targets in rendered_inventory["classes"].items():
-                for target_name in referenced_targets:
-                    self.targets[target_name].classes += class_name
+                self.targets[target_name].classes = rendered_target["classes"]
 
         except ReclassException as e:
             if isinstance(e, NotFoundError):


### PR DESCRIPTION
There's no need to reconstruct the list of classes for each target. Reclass provides this information in `rendered_target["classes"]` already.

This commit removes the loop which reconstructs the list and replaces it by assigning `rendered_target["classes"]` to the target's `classes` field.

Side-note: the previous implementation also mangled the list, because Python implements `+=` for lists as list concatenation, and (not so helpfully) treats strings as lists of characters when they appear in a context where a list is expected. To correctly construct the list of classes with the previous approach, the `+=` should be replaced with append:

```python
self.targets[target_name].classes.append(class_name)
```

## Docs and Tests

* [ ] Tests added
* [ ] Updated documentation