### PR TITLE
Refactor handling of inventory backend command line flag

### DIFF
--- a/docs/pages/commands/kapitan_compile.md
+++ b/docs/pages/commands/kapitan_compile.md
@@ -148,24 +148,28 @@ The `--embed-refs` flags tells **Kapitan** to embed these references on compile,
     ```
 
     ??? example "click to expand output"
-        ```shell
-        usage: kapitan compile [-h] [--search-paths JPATH [JPATH ...]]
-                              [--jinja2-filters FPATH] [--verbose] [--prune]
-                              [--quiet] [--output-path PATH] [--fetch]
-                              [--force-fetch] [--force] [--validate]
-                              [--parallelism INT] [--indent INT]
-                              [--refs-path REFS_PATH] [--reveal] [--embed-refs]
-                              [--inventory-path INVENTORY_PATH] [--cache]
-                              [--cache-paths PATH [PATH ...]]
-                              [--ignore-version-check] [--use-go-jsonnet]
-                              [--compose-node-name] [--schemas-path SCHEMAS_PATH]
-                              [--yaml-multiline-string-style STYLE]
-                              [--yaml-dump-null-as-empty]
-                              [--targets TARGET [TARGET ...] | --labels
-                              [key=value ...]]
 
-        optional arguments:
+        ```shell
+        usage: kapitan compile [-h] [--inventory-backend {reclass}]
+                       [--search-paths JPATH [JPATH ...]]
+                       [--jinja2-filters FPATH] [--verbose] [--prune]
+                       [--quiet] [--output-path PATH] [--fetch]
+                       [--force-fetch] [--force] [--validate]
+                       [--parallelism INT] [--indent INT]
+                       [--refs-path REFS_PATH] [--reveal] [--embed-refs]
+                       [--inventory-path INVENTORY_PATH] [--cache]
+                       [--cache-paths PATH [PATH ...]]
+                       [--ignore-version-check] [--use-go-jsonnet]
+                       [--compose-node-name] [--schemas-path SCHEMAS_PATH]
+                       [--yaml-multiline-string-style STYLE]
+                       [--yaml-dump-null-as-empty]
+                       [--targets TARGET [TARGET ...] | --labels
+                       [key=value ...]]
+
+        options:
           -h, --help            show this help message and exit
+          --inventory-backend {reclass}
+                                Select the inventory backend to use (default=reclass)
           --search-paths JPATH [JPATH ...], -J JPATH [JPATH ...]
                                 set search paths, default is ["."]
           --jinja2-filters FPATH, -J2F FPATH

--- a/docs/pages/commands/kapitan_dotfile.md
+++ b/docs/pages/commands/kapitan_dotfile.md
@@ -27,7 +27,7 @@ version: 0.30 # Allows any 0.30.x release to run
 ...
 ```
 
-### `compile`
+### Command line flags
 
 You can also permanently define all command line flags in the `.kapitan` config file. For example:
 
@@ -45,19 +45,16 @@ would be equivalent to running:
 kapitan compile --indent 4 --parallelism 8
 ```
 
-### inventory
+For flags which are shared by multiple commands, you can either selectively define them for single commmands in a section with the same name as the command, or you can set any flags in section `global`, in which case they're applied for all commands.
+If you set a flag in both the `global` section and a command's section, the value from the command's section takes precedence over the value from the global section.
 
-In some cases, you might want to store the inventory under a different directory. You can configure the `inventory` section of the **Kapitan** dotfile to make sure it's persisted across all **Kapitan** runs.
+As an example, you can configure the `inventory-path` in the `global` section of the **Kapitan** dotfile to make sure it's persisted across all **Kapitan** runs.
 
 ```yaml
 ...
 
-inventory:
+global:
   inventory-path: ./some_path
 ```
 
-which would be equivalent to always running:
-
-```shell
-kapitan inventory --inventory-path=./some_path
-```
+which would be equivalent to running any command with `--inventory-path=./some_path`.

--- a/docs/pages/commands/kapitan_dotfile.md
+++ b/docs/pages/commands/kapitan_dotfile.md
@@ -58,3 +58,14 @@ global:
 ```
 
 which would be equivalent to running any command with `--inventory-path=./some_path`.
+
+Another flag that you may want to set in the `global` section is `inventory-backend` to select a non-default inventory backend implementation.
+
+```yaml
+global:
+  inventory-backend: reclass
+```
+
+which would be equivalent to always running **Kapitan** with `--inventory-backend=reclass`.
+
+Please note that the `inventory-backend` flag currently can't be set through the command-specific sections of the **Kapitan** config file.

--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -21,6 +21,7 @@ import yaml
 from kapitan import cached, defaults, setup_logging
 from kapitan.initialiser import initialise_skeleton
 from kapitan.inputs.jsonnet import jsonnet_file
+from kapitan.inventory import AVAILABLE_BACKENDS
 from kapitan.lint import start_lint
 from kapitan.refs.base import RefController, Revealer
 from kapitan.refs.cmd_parser import handle_refs_command
@@ -103,12 +104,12 @@ def build_parser():
     subparser = parser.add_subparsers(help="commands", dest="subparser_name")
 
     inventory_backend_parser = argparse.ArgumentParser(add_help=False)
-    inventory_backend_group = inventory_backend_parser.add_argument_group("inventory_backend")
-    inventory_backend_group.add_argument(
-        "--reclass",
-        action="store_true",
-        default=from_dot_kapitan("inventory_backend", "reclass", False),
-        help="use reclass as inventory backend (default)",
+    inventory_backend_parser.add_argument(
+        "--inventory-backend",
+        action="store",
+        default=from_dot_kapitan("inventory_backend", "inventory-backend", "reclass"),
+        choices=AVAILABLE_BACKENDS.keys(),
+        help="Select the inventory backend to use (default=reclass)",
     )
 
     eval_parser = subparser.add_parser("eval", aliases=["e"], help="evaluate jsonnet file")
@@ -663,6 +664,8 @@ def main():
     # cache args where key is subcommand
     assert "name" in args, "All cli commands must have provided default name"
     cached.args[args.name] = args
+    if "inventory_backend" in args:
+        cached.args["inventory-backend"] = args.inventory_backend
 
     if hasattr(args, "verbose") and args.verbose:
         setup_logging(level=logging.DEBUG, force=True)

--- a/kapitan/inventory/__init__.py
+++ b/kapitan/inventory/__init__.py
@@ -1,2 +1,10 @@
+from typing import Type
+
 from .inv_reclass import ReclassInventory
 from .inventory import Inventory
+
+# Dict mapping values for command line flag `--inventory-backend` to the
+# associated `Inventory` subclass.
+AVAILABLE_BACKENDS: dict[str, Type[Inventory]] = {
+    "reclass": ReclassInventory,
+}

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -410,19 +410,15 @@ def dot_kapitan_config():
 
 def from_dot_kapitan(command, flag, default):
     """
-    Returns the 'flag' for 'command' from .kapitan file. If failed, returns 'default'
+    Returns the 'flag' from the '<command>' or from the 'global' section in the  .kapitan file. If
+    neither section proivdes a value for the flag, the value passed in `default` is returned.
     """
     kapitan_config = dot_kapitan_config()
 
-    try:
-        if kapitan_config[command]:
-            flag_value = kapitan_config[command][flag]
-            if flag_value:
-                return flag_value
-    except KeyError:
-        pass
+    global_config = kapitan_config.get("global", {})
+    cmd_config = kapitan_config.get(command, {})
 
-    return default
+    return cmd_config.get(flag, global_config.get(flag, default))
 
 
 def compare_versions(v1_raw, v2_raw):

--- a/tests/test_from_dot_kapitan.py
+++ b/tests/test_from_dot_kapitan.py
@@ -1,0 +1,53 @@
+import os
+import shutil
+import tempfile
+import unittest
+import yaml
+
+from kapitan.utils import from_dot_kapitan
+from kapitan.cached import reset_cache
+
+
+class FromDotKapitanTest(unittest.TestCase):
+    "Test loading flags from .kapitan"
+
+    def _setup_dot_kapitan(self, config):
+        with open(self.work_dir.name + "/.kapitan", "w", encoding="utf-8") as f:
+            yaml.safe_dump(config, f)
+
+    def setUp(self):
+        self.orig_dir = os.getcwd()
+        self.work_dir = tempfile.TemporaryDirectory()
+        os.chdir(self.work_dir.name)
+
+    def test_no_file(self):
+        assert from_dot_kapitan("compile", "inventory-path", "./some/fallback") == "./some/fallback"
+
+    def test_no_option(self):
+        self._setup_dot_kapitan(
+            {"global": {"inventory-backend": "reclass"}, "compile": {"inventory-path": "./path/to/inv"}}
+        )
+        assert from_dot_kapitan("inventory", "inventory-path", "./some/fallback") == "./some/fallback"
+
+    def test_cmd_option(self):
+        self._setup_dot_kapitan(
+            {"global": {"inventory-backend": "reclass"}, "compile": {"inventory-path": "./path/to/inv"}}
+        )
+        assert from_dot_kapitan("compile", "inventory-path", "./some/fallback") == "./path/to/inv"
+
+    def test_global_option(self):
+        self._setup_dot_kapitan(
+            {"global": {"inventory-path": "./some/path"}, "compile": {"inventory-path": "./path/to/inv"}}
+        )
+        assert from_dot_kapitan("inventory", "inventory-path", "./some/fallback") == "./some/path"
+
+    def test_command_over_global_option(self):
+        self._setup_dot_kapitan(
+            {"global": {"inventory-path": "./some/path"}, "compile": {"inventory-path": "./path/to/inv"}}
+        )
+        assert from_dot_kapitan("compile", "inventory-path", "./some/fallback") == "./path/to/inv"
+
+    def tearDown(self):
+        self.work_dir.cleanup()
+        os.chdir(self.orig_dir)
+        reset_cache()


### PR DESCRIPTION
## Proposed Changes

This PR switches the inventory backend command line flag to the form `--inventory-backend=<backend name>`. Additionally, we restrict the allowed values for the flag to the known backends.

To ensure the allowed values for the command line flag, and the known implementations are in sync, we introduce a dict holding the mapping from flag values to `Inventory` subclasses.

Finally, we ensure that the selected backend is cached as a string in `cached.args["inventory-backend"]`. Note that this is not how `cached.args` is used otherwise, but since it's unlikely that there ever will be a real command `inventory-backend` this should be fine.

## Docs and Tests

* [ ] Tests added
* [x] Updated documentation