### PR TITLE
Add support for `global` section in `.kapitan`

### DIFF
--- a/docs/pages/commands/kapitan_dotfile.md
+++ b/docs/pages/commands/kapitan_dotfile.md
@@ -27,7 +27,7 @@ version: 0.30 # Allows any 0.30.x release to run
 ...
 ```
 
-### `compile`
+### Command line flags
 
 You can also permanently define all command line flags in the `.kapitan` config file. For example:
 
@@ -45,19 +45,16 @@ would be equivalent to running:
 kapitan compile --indent 4 --parallelism 8
 ```
 
-### inventory
+For flags which are shared by multiple commands, you can either selectively define them for single commmands in a section with the same name as the command, or you can set any flags in section `global`, in which case they're applied for all commands.
+If you set a flag in both the `global` section and a command's section, the value from the command's section takes precedence over the value from the global section.
 
-In some cases, you might want to store the inventory under a different directory. You can configure the `inventory` section of the **Kapitan** dotfile to make sure it's persisted across all **Kapitan** runs.
+As an example, you can configure the `inventory-path` in the `global` section of the **Kapitan** dotfile to make sure it's persisted across all **Kapitan** runs.
 
 ```yaml
 ...
 
-inventory:
+global:
   inventory-path: ./some_path
 ```
 
-which would be equivalent to always running:
-
-```shell
-kapitan inventory --inventory-path=./some_path
-```
+which would be equivalent to running any command with `--inventory-path=./some_path`.

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -410,19 +410,15 @@ def dot_kapitan_config():
 
 def from_dot_kapitan(command, flag, default):
     """
-    Returns the 'flag' for 'command' from .kapitan file. If failed, returns 'default'
+    Returns the 'flag' from the '<command>' or from the 'global' section in the  .kapitan file. If
+    neither section proivdes a value for the flag, the value passed in `default` is returned.
     """
     kapitan_config = dot_kapitan_config()
 
-    try:
-        if kapitan_config[command]:
-            flag_value = kapitan_config[command][flag]
-            if flag_value:
-                return flag_value
-    except KeyError:
-        pass
+    global_config = kapitan_config.get("global", {})
+    cmd_config = kapitan_config.get(command, {})
 
-    return default
+    return cmd_config.get(flag, global_config.get(flag, default))
 
 
 def compare_versions(v1_raw, v2_raw):

--- a/tests/test_from_dot_kapitan.py
+++ b/tests/test_from_dot_kapitan.py
@@ -1,0 +1,53 @@
+import os
+import shutil
+import tempfile
+import unittest
+import yaml
+
+from kapitan.utils import from_dot_kapitan
+from kapitan.cached import reset_cache
+
+
+class FromDotKapitanTest(unittest.TestCase):
+    "Test loading flags from .kapitan"
+
+    def _setup_dot_kapitan(self, config):
+        with open(self.work_dir.name + "/.kapitan", "w", encoding="utf-8") as f:
+            yaml.safe_dump(config, f)
+
+    def setUp(self):
+        self.orig_dir = os.getcwd()
+        self.work_dir = tempfile.TemporaryDirectory()
+        os.chdir(self.work_dir.name)
+
+    def test_no_file(self):
+        assert from_dot_kapitan("compile", "inventory-path", "./some/fallback") == "./some/fallback"
+
+    def test_no_option(self):
+        self._setup_dot_kapitan(
+            {"global": {"inventory-backend": "reclass"}, "compile": {"inventory-path": "./path/to/inv"}}
+        )
+        assert from_dot_kapitan("inventory", "inventory-path", "./some/fallback") == "./some/fallback"
+
+    def test_cmd_option(self):
+        self._setup_dot_kapitan(
+            {"global": {"inventory-backend": "reclass"}, "compile": {"inventory-path": "./path/to/inv"}}
+        )
+        assert from_dot_kapitan("compile", "inventory-path", "./some/fallback") == "./path/to/inv"
+
+    def test_global_option(self):
+        self._setup_dot_kapitan(
+            {"global": {"inventory-path": "./some/path"}, "compile": {"inventory-path": "./path/to/inv"}}
+        )
+        assert from_dot_kapitan("inventory", "inventory-path", "./some/fallback") == "./some/path"
+
+    def test_command_over_global_option(self):
+        self._setup_dot_kapitan(
+            {"global": {"inventory-path": "./some/path"}, "compile": {"inventory-path": "./path/to/inv"}}
+        )
+        assert from_dot_kapitan("compile", "inventory-path", "./some/fallback") == "./path/to/inv"
+
+    def tearDown(self):
+        self.work_dir.cleanup()
+        os.chdir(self.orig_dir)
+        reset_cache()


### PR DESCRIPTION
## Proposed Changes

* Introduce section `global` in the `.kapitan` config file as discussed in #1127 

## Docs and Tests

* [x] Tests added
* [x] Updated documentation