### PR TITLE
Don't call `render_targets()` from `get_targets()` when all requested targets are cached

### DIFF
--- a/kapitan/inventory/inventory.py
+++ b/kapitan/inventory/inventory.py
@@ -111,7 +111,8 @@ class Inventory(ABC):
             if not target.parameters:
                 targets_to_render.append(target)
 
-        self.render_targets(targets_to_render, ignore_class_not_found)
+        if targets_to_render:
+            self.render_targets(targets_to_render, ignore_class_not_found)
 
         return {name: target for name, target in self.targets.items() if name in target_names}
 


### PR DESCRIPTION
## Proposed Changes

Only render Reclass inventory if `render_targets()` is called with either `targets=None` or a non-empty list of targets to render. Without this, the whole Reclass inventory is rendered for pretty much every call to `get_targets()` since that method calls `render_targets()` with `targets=[]` if it already has parameters for all targets.

## Docs and Tests

* [ ] Tests added
* [ ] Updated documentation