### PR TITLE
Expose `applications` and `exports` fields in `InventoryTarget` and Jsonnet `inventory()` callback

### DIFF
--- a/examples/kubernetes/compiled/jsonnet-env/jsonnet-env/env.yml
+++ b/examples/kubernetes/compiled/jsonnet-env/jsonnet-env/env.yml
@@ -1,0 +1,44 @@
+applications:
+  - a
+  - b
+  - c
+classes:
+  - common
+  - jsonnet-env
+exports: {}
+parameters:
+  _reclass_:
+    environment: base
+    name:
+      full: jsonnet-env
+      parts:
+        - jsonnet-env
+      path: jsonnet-env
+      short: jsonnet-env
+  a: aaaaa
+  b: bbbbb
+  c: ccccc
+  kapitan:
+    compile:
+      - input_params: {}
+        input_paths:
+          - components/jsonnet-env/env.jsonnet
+        input_type: jsonnet
+        output_path: jsonnet-env
+        output_type: yml
+    secrets:
+      awskms:
+        key: alias/nameOfKey
+      gkms:
+        key: projects/<project>/locations/<location>/keyRings/<keyRing>/cryptoKeys/<key>
+      gpg:
+        recipients:
+          - fingerprint: D9234C61F58BEB3ED8552A57E28DC07A3CBFAE7C
+            name: example@kapitan.dev
+    target_full_path: jsonnet-env
+    vars:
+      managed_by: kapitan
+      namespace: jsonnet-env
+      target: jsonnet-env
+  namespace: jsonnet-env
+  target_name: jsonnet-env

--- a/examples/kubernetes/components/jsonnet-env/env.jsonnet
+++ b/examples/kubernetes/components/jsonnet-env/env.jsonnet
@@ -1,0 +1,11 @@
+local kap = import 'lib/kapitan.libjsonnet';
+local inventory = kap.inventory();
+
+{
+  env: {
+    applications: inventory.applications,
+    classes: inventory.classes,
+    parameters: inventory.parameters,
+    exports: inventory.exports,
+  },
+}

--- a/examples/kubernetes/inventory/classes/jsonnet-env.yml
+++ b/examples/kubernetes/inventory/classes/jsonnet-env.yml
@@ -1,0 +1,12 @@
+applications:
+  - a
+  - b
+  - c
+
+classes:
+  - common
+
+parameters:
+  a: aaaaa
+  b: bbbbb
+  c: ccccc

--- a/examples/kubernetes/inventory/targets/jsonnet-env.yml
+++ b/examples/kubernetes/inventory/targets/jsonnet-env.yml
@@ -1,0 +1,12 @@
+classes:
+  - jsonnet-env
+
+parameters:
+  target_name: jsonnet-env
+  kapitan:
+    compile:
+      - output_path: jsonnet-env
+        input_type: jsonnet
+        input_paths:
+          - components/jsonnet-env/env.jsonnet
+        output_type: yml

--- a/kapitan/inventory/inv_reclass.py
+++ b/kapitan/inventory/inv_reclass.py
@@ -14,7 +14,6 @@ logger = logging.getLogger(__name__)
 
 
 class ReclassInventory(Inventory):
-    
     def render_targets(self, targets: list = None, ignore_class_notfound: bool = False):
         """
         Runs a reclass inventory in inventory_path
@@ -28,7 +27,7 @@ class ReclassInventory(Inventory):
         reclass_config = get_reclass_config(self.inventory_path)
         reclass_config.setdefault("ignore_class_notfound", ignore_class_notfound)
         reclass_config["compose_node_name"] = self.compose_target_name
-        
+
         try:
             storage = reclass.get_storage(
                 reclass_config["storage_type"],
@@ -44,6 +43,8 @@ class ReclassInventory(Inventory):
             for target_name, rendered_target in rendered_inventory["nodes"].items():
                 self.targets[target_name].parameters = rendered_target["parameters"]
                 self.targets[target_name].classes = rendered_target["classes"]
+                self.targets[target_name].applications = rendered_target["applications"]
+                self.targets[target_name].exports = rendered_target["exports"]
 
         except ReclassException as e:
             if isinstance(e, NotFoundError):
@@ -79,7 +80,9 @@ def get_reclass_config(inventory_path: str) -> dict:
             for key, value in config.items():
                 reclass_config[key] = value
         else:
-            logger.debug(f"Reclass config: Empty config file at {cfg_file}. Using reclass inventory config defaults")
+            logger.debug(
+                f"Reclass config: Empty config file at {cfg_file}. Using reclass inventory config defaults"
+            )
     else:
         logger.debug("Inventory reclass: No config file found. Using reclass inventory config defaults")
 

--- a/kapitan/inventory/inventory.py
+++ b/kapitan/inventory/inventory.py
@@ -25,6 +25,8 @@ class InventoryTarget:
     composed_name: str
     parameters: dict = field(default_factory=dict)
     classes: list = field(default_factory=list)
+    applications: list = field(default_factory=list)
+    exports: list = field(default_factory=list)
 
 
 class Inventory(ABC):

--- a/kapitan/resources.py
+++ b/kapitan/resources.py
@@ -8,6 +8,7 @@
 "kapitan resources"
 
 import base64
+import dataclasses
 import gzip
 import io
 import json
@@ -278,7 +279,7 @@ def inventory(search_paths: list, target_name: str = None, inventory_path: str =
 
     if target_name:
         target = inv.get_target(target_name)
-        return {"parameters": target.parameters, "classes": target.classes}
+        return dataclasses.asdict(target)
 
     return inv.inventory
 

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -211,6 +211,24 @@ class CompileKubernetesTest(unittest.TestCase):
         sys.argv = ["kapitan", "compile"]
         main()
 
+    def test_compile_jsonnet_env(self):
+        shutil.rmtree("compiled")
+        sys.argv = ["kapitan", "compile", "-t", "jsonnet-env"]
+        main()
+        self.assertTrue(os.path.exists("compiled/jsonnet-env/jsonnet-env/env.yml"))
+        with open("compiled/jsonnet-env/jsonnet-env/env.yml", "r", encoding="utf-8") as f:
+            env = dict(yaml.safe_load(f))
+            self.assertEqual(set(env.keys()), {"applications", "parameters", "classes", "exports"})
+            self.assertEqual(env["applications"], ["a", "b", "c"])
+            self.assertEqual(env["classes"], ["common", "jsonnet-env"])
+            self.assertTrue("a" in env["parameters"])
+            self.assertEqual(env["parameters"]["a"], "aaaaa")
+            self.assertTrue("b" in env["parameters"])
+            self.assertEqual(env["parameters"]["b"], "bbbbb")
+            self.assertTrue("c" in env["parameters"])
+            self.assertEqual(env["parameters"]["c"], "ccccc")
+            self.assertEqual(env["exports"], {})
+
     def tearDown(self):
         os.chdir(os.getcwd() + "/../../")
         reset_cache()

--- a/tests/test_kubernetes_compiled/jsonnet-env/jsonnet-env/env.yml
+++ b/tests/test_kubernetes_compiled/jsonnet-env/jsonnet-env/env.yml
@@ -1,0 +1,44 @@
+applications:
+  - a
+  - b
+  - c
+classes:
+  - common
+  - jsonnet-env
+exports: {}
+parameters:
+  _reclass_:
+    environment: base
+    name:
+      full: jsonnet-env
+      parts:
+        - jsonnet-env
+      path: jsonnet-env
+      short: jsonnet-env
+  a: aaaaa
+  b: bbbbb
+  c: ccccc
+  kapitan:
+    compile:
+      - input_params: {}
+        input_paths:
+          - components/jsonnet-env/env.jsonnet
+        input_type: jsonnet
+        output_path: jsonnet-env
+        output_type: yml
+    secrets:
+      awskms:
+        key: alias/nameOfKey
+      gkms:
+        key: projects/<project>/locations/<location>/keyRings/<keyRing>/cryptoKeys/<key>
+      gpg:
+        recipients:
+          - fingerprint: D9234C61F58BEB3ED8552A57E28DC07A3CBFAE7C
+            name: example@kapitan.dev
+    target_full_path: jsonnet-env
+    vars:
+      managed_by: kapitan
+      namespace: jsonnet-env
+      target: jsonnet-env
+  namespace: jsonnet-env
+  target_name: jsonnet-env


### PR DESCRIPTION
## Proposed Changes

* Restore the Kapitan <= 0.32 behavior of exposing the Reclass `applications`  (which Commodore depends on) and `exports` fields in the inventory

## Docs and Tests

* [x] Tests added
* [ ] Updated documentation