### PR TITLE
chore: bump Dockerfile golang version to 1.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN python -m venv $VIRTUAL_ENV \
     && pip install --upgrade pip yq wheel poetry==$POETRY_VERSION
 
 # Install Go (for go-jsonnet)
-RUN curl -fsSL -o go.tar.gz https://go.dev/dl/go1.20.8.linux-${TARGETARCH}.tar.gz \
+RUN curl -fsSL -o go.tar.gz https://go.dev/dl/go1.21.7.linux-${TARGETARCH}.tar.gz \
     && tar -C /usr/local -xzf go.tar.gz \
     && rm go.tar.gz
 


### PR DESCRIPTION
As specified by the golang [release policy](https://go.dev/doc/devel/release#policy), "each major go release is supported until there are two newer major releases", which mean that the oldest supported version is currently go 1.21.