### PR TITLE
Completely remove any references to distutils

### DIFF
--- a/kapitan/dependency_manager/base.py
+++ b/kapitan/dependency_manager/base.py
@@ -7,7 +7,6 @@ import logging
 import multiprocessing
 import os
 from collections import defaultdict, namedtuple
-from distutils.dir_util import copy_tree
 from functools import partial
 from mimetypes import MimeTypes
 from shutil import copyfile, rmtree
@@ -17,6 +16,7 @@ from git import Repo
 from kapitan.errors import GitSubdirNotFoundError, GitFetchingError, HelmFetchingError
 from kapitan.helm_cli import helm_cli
 from kapitan.utils import (
+    copy_tree,
     make_request,
     unpack_downloaded_file,
     safe_copy_tree,
@@ -129,7 +129,7 @@ def fetch_git_dependency(dep_mapping, save_dir, force, item_type="Dependency"):
                     "{} {}: subdir {} not found in repo".format(item_type, source, sub_dir)
                 )
         if force:
-            copied = copy_tree(copy_src_path, output_path, verbose=0)
+            copied = copy_tree(copy_src_path, output_path)
         else:
             copied = safe_copy_tree(copy_src_path, output_path)
         if copied:
@@ -245,7 +245,7 @@ def fetch_helm_chart(dep_mapping, save_dir, force):
             os.makedirs(parent_dir, exist_ok=True)
 
         if force:
-            copied = copy_tree(cached_repo_path, output_path, verbose=0)
+            copied = copy_tree(cached_repo_path, output_path)
         else:
             copied = safe_copy_tree(cached_repo_path, output_path)
 

--- a/kapitan/initialiser.py
+++ b/kapitan/initialiser.py
@@ -9,7 +9,7 @@
 
 import logging
 import os
-from distutils.dir_util import copy_tree
+from kapitan.utils import copy_tree
 
 logger = logging.getLogger(__name__)
 

--- a/kapitan/inputs/copy.py
+++ b/kapitan/inputs/copy.py
@@ -8,7 +8,7 @@
 import logging
 import os
 import shutil
-from distutils.dir_util import copy_tree
+from kapitan.utils import copy_tree
 
 from kapitan.inputs.base import InputType
 

--- a/kapitan/inputs/external.py
+++ b/kapitan/inputs/external.py
@@ -10,7 +10,7 @@ import re
 import logging
 import os
 import shutil
-from distutils.dir_util import copy_tree
+from kapitan.utils import copy_tree
 
 from kapitan.inputs.base import InputType
 

--- a/kapitan/inputs/remove.py
+++ b/kapitan/inputs/remove.py
@@ -8,7 +8,7 @@
 import logging
 import os
 import shutil
-from distutils.dir_util import copy_tree
+from kapitan.utils import copy_tree
 
 from kapitan.inputs.base import InputType
 

--- a/tests/test_remote_inventory.py
+++ b/tests/test_remote_inventory.py
@@ -4,7 +4,7 @@ import sys
 import unittest
 import tempfile
 from shutil import rmtree
-from distutils.dir_util import copy_tree
+from kapitan.utils import copy_tree
 from kapitan.cached import reset_cache
 from kapitan.cli import main
 import yaml


### PR DESCRIPTION
Fixes #963.

## Proposed Changes

Whereas #964 just attempted to replace copy_tree, this replaces all the remaining references to distutils. This ought to make it possible to proceed with #1119 and add Python 3.12 to the test set.

## Docs and Tests

* [x] Tests added (existing tests cover the changes)
* [x] Updated documentation (internal functional change that doesn't need external docs)