### PR TITLE
feat:  Add a --no-reveal flag in compile command to avoid revealing refs

### DIFF
--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -251,7 +251,7 @@ def build_parser():
     compile_parser.add_argument(
         "--reveal",
         help="reveal refs (warning: this will potentially write sensitive data)",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
         default=from_dot_kapitan("compile", "reveal", False),
     )
     compile_parser.add_argument(
@@ -662,8 +662,8 @@ def main():
         parser.print_help()
         sys.exit(1)
 
-    cached.args = args  
-    
+    cached.args = args
+
     if hasattr(args, "verbose") and args.verbose:
         logging_level = logging.DEBUG
     elif hasattr(args, "quiet") and args.quiet:

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -39,6 +39,14 @@ class CompileTestResourcesTestObjs(unittest.TestCase):
             with open(g) as f:
                 self.assertTrue("?{plain:" not in f.read())
 
+    def test_compile_no_reveal(self):
+        # check if the --no-reveal flag takes precedence over --reveal when passed together
+        sys.argv = ["kapitan", "compile", "-t", "reveal-output", "--reveal", "--no-reveal"]
+        main()
+
+        with open("compiled/reveal-output/main.json") as f:
+            self.assertTrue("?{gpg:" in f.read())
+
     def tearDown(self):
         os.chdir(os.getcwd() + "/../../")
         reset_cache()
@@ -86,7 +94,7 @@ class FailCompileTestResourcesTestKadet(unittest.TestCase):
     def tearDown(self):
         os.chdir(os.getcwd() + "/../../")
         reset_cache()
-        
+
 class CompileTestResourcesTestJinja2InputParams(unittest.TestCase):
     def setUp(self):
         os.chdir(os.getcwd() + "/tests/test_resources/")

--- a/tests/test_resources/inventory/targets/reveal-output.yml
+++ b/tests/test_resources/inventory/targets/reveal-output.yml
@@ -1,0 +1,12 @@
+parameters:
+  input: $?{gpg:targets/nginx-ingress/electionID||randomstr|base64}
+  kapitan:
+    vars:
+      target: reveal-output
+    compile:
+      - name: generate-toml-jsonnet
+        input_type: jsonnet
+        output_path: .
+        output_type: json
+        input_paths:
+          - components/input-to-output/main.jsonnet


### PR DESCRIPTION
## Proposed Changes

* Add a `--no-reveal` flag to compile command to avoid revealing secret (useful if a `reveal: true` is set in the `.kapitan` config file) 

## Docs and Tests

* [x] Tests added
* [] Updated documentation