### PR TITLE
Correctly specify `InventoryTarget.exports` field as a `dict`

### DIFF
--- a/kapitan/inventory/inventory.py
+++ b/kapitan/inventory/inventory.py
@@ -20,7 +20,7 @@ class InventoryTarget(BaseModel):
     parameters: dict = dict()
     classes: list = list()
     applications: list = list()
-    exports: list = list()
+    exports: dict = dict()
 
 
 class Inventory(ABC):


### PR DESCRIPTION
## Proposed Changes

This PR adjusts the type annotation and initialization for `InventoryTarget.exports` to be a `dict` which is the correct type for the reclass `exports` field.

Without this, Kapitan logs the following warning multiple times when running `poetry run make test`:

```
/home/simon/.cache/pypoetry/virtualenvs/kapitan-f1_prbYm-py3.10/lib/python3.10/site-packages/pydantic/main.py:314: UserWarning: Pydantic serializer warnings:
  Expected `list[any]` but got `dict` - serialized value may not be as expected
  return self.__pydantic_serializer__.to_python(
```

## Docs and Tests

* [ ] Tests added
* [ ] Updated documentation