### PR TITLE
Fix reclass-rs considered optional by pip and friends

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ COPY ./poetry.lock ./poetry.lock
 COPY ./README.md ./README.md
 
 # Installs and caches dependencies
-RUN poetry install --no-root --extras=gojsonnet --extras=reclass-rs
+RUN poetry install --no-root --extras=gojsonnet
 
 COPY ./kapitan ./kapitan
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2717,10 +2717,9 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 
 [extras]
 gojsonnet = ["gojsonnet"]
-reclass-rs = ["reclass-rs"]
-test = ["docker", "reclass-rs"]
+test = ["docker"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10,<3.12"
-content-hash = "9b633a77abd182a48677c02195dd64c555517309279efba92b8a97648a887597"
+content-hash = "be351e8318b75d36247adaa078cc9ba85548e8d8e07748d62e969b60ad5365cb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,8 +79,7 @@ omegaconf = "^2.4.0.dev3"
 
 [tool.poetry.extras]
 gojsonnet = ["gojsonnet"]
-test = ["docker", "reclass-rs"]
-reclass-rs = ["reclass-rs"]
+test = ["docker"]
 
 [tool.black]
 line-length = 110


### PR DESCRIPTION
It seems the reason is that it was mentioned in tool.poetry.extras.

Fixes #1210

## Proposed Changes

Remove reclass-rs from extras to fix pip / pipx / uv not installing it. 

## Docs and Tests

* [ ] Tests added
* [ ] Updated documentation