### PR TITLE
Add optional `force_fetch` field for all dependency types

### DIFF
--- a/kapitan/inventory/model/dependencies.py
+++ b/kapitan/inventory/model/dependencies.py
@@ -17,6 +17,7 @@ class KapitanDependencyBaseConfig(BaseModel):
     type: KapitanDependencyTypes
     source: str
     output_path: str
+    force_fetch: Optional[bool] = False
 
 
 class KapitanDependencyHelmConfig(KapitanDependencyBaseConfig):
@@ -24,7 +25,6 @@ class KapitanDependencyHelmConfig(KapitanDependencyBaseConfig):
     chart_name: str
     version: Optional[str] = None
     helm_path: Optional[str] = None
-    force_fetch: Optional[bool] = False
 
 
 class KapitanDependencyGitConfig(KapitanDependencyBaseConfig):


### PR DESCRIPTION
## Proposed Changes

Move the optional `force_fetch` field to the `KapitanDependencyBaseConfig` type.

We access the `force_fetch` field without regard to the dependency type in https://github.com/kapicorp/kapitan/blob/593e5f90888fcd48bed2477f1f22407187e1845b/kapitan/targets.py#L118

## Docs and Tests

* [ ] Tests added
* [ ] Updated documentation
