### PR TITLE
Upgrade go to 1.23.2 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN python -m venv $VIRTUAL_ENV \
     && pip install --upgrade pip yq wheel poetry==$POETRY_VERSION
 
 # Install Go (for go-jsonnet)
-RUN curl -fsSL -o go.tar.gz https://go.dev/dl/go1.21.7.linux-${TARGETARCH}.tar.gz \
+RUN curl -fsSL -o go.tar.gz https://go.dev/dl/go1.23.2.linux-${TARGETARCH}.tar.gz \
     && tar -C /usr/local -xzf go.tar.gz \
     && rm go.tar.gz
 


### PR DESCRIPTION
## Proposed Changes

As go 1.21 is end of life, upgrade go to 1.23.2 version in Dockerfile.

## Docs and Tests

* [ ] Tests added
* [ ] Updated documentation
