### PR TITLE
Update reclass-rs to ^0.6.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -157,32 +157,32 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "boto3"
-version = "1.35.93"
+version = "1.36.0"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "boto3-1.35.93-py3-none-any.whl", hash = "sha256:7de2c44c960e486f3c57e5203ea6393c6c4f0914c5f81c789ceb8b5d2ba5d1c5"},
-    {file = "boto3-1.35.93.tar.gz", hash = "sha256:2446e819cf4e295833474cdcf2c92bc82718ce537e9ee1f17f7e3d237f60e69b"},
+    {file = "boto3-1.36.0-py3-none-any.whl", hash = "sha256:d0ca7a58ce25701a52232cc8df9d87854824f1f2964b929305722ebc7959d5a9"},
+    {file = "boto3-1.36.0.tar.gz", hash = "sha256:159898f51c2997a12541c0e02d6e5a8fe2993ddb307b9478fd9a339f98b57e00"},
 ]
 
 [package.dependencies]
-botocore = ">=1.35.93,<1.36.0"
+botocore = ">=1.36.0,<1.37.0"
 jmespath = ">=0.7.1,<2.0.0"
-s3transfer = ">=0.10.0,<0.11.0"
+s3transfer = ">=0.11.0,<0.12.0"
 
 [package.extras]
 crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.35.93"
+version = "1.36.0"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "botocore-1.35.93-py3-none-any.whl", hash = "sha256:47f7161000af6036f806449e3de12acdd3ec11aac7f5578e43e96241413a0f8f"},
-    {file = "botocore-1.35.93.tar.gz", hash = "sha256:b8d245a01e7d64c41edcf75a42be158df57b9518a83a3dbf5c7e4b8c2bc540cc"},
+    {file = "botocore-1.36.0-py3-none-any.whl", hash = "sha256:b54b11f0cfc47fc1243ada0f7f461266c279968487616720fa8ebb02183917d7"},
+    {file = "botocore-1.36.0.tar.gz", hash = "sha256:0232029ff9ae3f5b50cdb25cbd257c16f87402b6d31a05bd6483638ee6434c4b"},
 ]
 
 [package.dependencies]
@@ -191,7 +191,7 @@ python-dateutil = ">=2.1,<3.0.0"
 urllib3 = {version = ">=1.25.4,<2.2.0 || >2.2.0,<3", markers = "python_version >= \"3.10\""}
 
 [package.extras]
-crt = ["awscrt (==0.22.0)"]
+crt = ["awscrt (==0.23.4)"]
 
 [[package]]
 name = "cachetools"
@@ -829,13 +829,13 @@ grpcio-gcp = ["grpcio-gcp (>=0.2.2,<1.0.dev0)"]
 
 [[package]]
 name = "google-api-python-client"
-version = "2.157.0"
+version = "2.159.0"
 description = "Google API Client Library for Python"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "google_api_python_client-2.157.0-py2.py3-none-any.whl", hash = "sha256:0b0231db106324c659bf8b85f390391c00da57a60ebc4271e33def7aac198c75"},
-    {file = "google_api_python_client-2.157.0.tar.gz", hash = "sha256:2ee342d0967ad1cedec43ccd7699671d94bff151e1f06833ea81303f9a6d86fd"},
+    {file = "google_api_python_client-2.159.0-py2.py3-none-any.whl", hash = "sha256:baef0bb631a60a0bd7c0bf12a5499e3a40cd4388484de7ee55c1950bf820a0cf"},
+    {file = "google_api_python_client-2.159.0.tar.gz", hash = "sha256:55197f430f25c907394b44fa078545ffef89d33fd4dca501b7db9f0d8e224bd6"},
 ]
 
 [package.dependencies]
@@ -1671,22 +1671,22 @@ testing = ["google-api-core (>=1.31.5)"]
 
 [[package]]
 name = "protobuf"
-version = "5.29.2"
+version = "5.29.3"
 description = ""
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "protobuf-5.29.2-cp310-abi3-win32.whl", hash = "sha256:c12ba8249f5624300cf51c3d0bfe5be71a60c63e4dcf51ffe9a68771d958c851"},
-    {file = "protobuf-5.29.2-cp310-abi3-win_amd64.whl", hash = "sha256:842de6d9241134a973aab719ab42b008a18a90f9f07f06ba480df268f86432f9"},
-    {file = "protobuf-5.29.2-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:a0c53d78383c851bfa97eb42e3703aefdc96d2036a41482ffd55dc5f529466eb"},
-    {file = "protobuf-5.29.2-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:494229ecd8c9009dd71eda5fd57528395d1eacdf307dbece6c12ad0dd09e912e"},
-    {file = "protobuf-5.29.2-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:b6b0d416bbbb9d4fbf9d0561dbfc4e324fd522f61f7af0fe0f282ab67b22477e"},
-    {file = "protobuf-5.29.2-cp38-cp38-win32.whl", hash = "sha256:e621a98c0201a7c8afe89d9646859859be97cb22b8bf1d8eacfd90d5bda2eb19"},
-    {file = "protobuf-5.29.2-cp38-cp38-win_amd64.whl", hash = "sha256:13d6d617a2a9e0e82a88113d7191a1baa1e42c2cc6f5f1398d3b054c8e7e714a"},
-    {file = "protobuf-5.29.2-cp39-cp39-win32.whl", hash = "sha256:36000f97ea1e76e8398a3f02936aac2a5d2b111aae9920ec1b769fc4a222c4d9"},
-    {file = "protobuf-5.29.2-cp39-cp39-win_amd64.whl", hash = "sha256:2d2e674c58a06311c8e99e74be43e7f3a8d1e2b2fdf845eaa347fbd866f23355"},
-    {file = "protobuf-5.29.2-py3-none-any.whl", hash = "sha256:fde4554c0e578a5a0bcc9a276339594848d1e89f9ea47b4427c80e5d72f90181"},
-    {file = "protobuf-5.29.2.tar.gz", hash = "sha256:b2cc8e8bb7c9326996f0e160137b0861f1a82162502658df2951209d0cb0309e"},
+    {file = "protobuf-5.29.3-cp310-abi3-win32.whl", hash = "sha256:3ea51771449e1035f26069c4c7fd51fba990d07bc55ba80701c78f886bf9c888"},
+    {file = "protobuf-5.29.3-cp310-abi3-win_amd64.whl", hash = "sha256:a4fa6f80816a9a0678429e84973f2f98cbc218cca434abe8db2ad0bffc98503a"},
+    {file = "protobuf-5.29.3-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:a8434404bbf139aa9e1300dbf989667a83d42ddda9153d8ab76e0d5dcaca484e"},
+    {file = "protobuf-5.29.3-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:daaf63f70f25e8689c072cfad4334ca0ac1d1e05a92fc15c54eb9cf23c3efd84"},
+    {file = "protobuf-5.29.3-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:c027e08a08be10b67c06bf2370b99c811c466398c357e615ca88c91c07f0910f"},
+    {file = "protobuf-5.29.3-cp38-cp38-win32.whl", hash = "sha256:84a57163a0ccef3f96e4b6a20516cedcf5bb3a95a657131c5c3ac62200d23252"},
+    {file = "protobuf-5.29.3-cp38-cp38-win_amd64.whl", hash = "sha256:b89c115d877892a512f79a8114564fb435943b59067615894c3b13cd3e1fa107"},
+    {file = "protobuf-5.29.3-cp39-cp39-win32.whl", hash = "sha256:0eb32bfa5219fc8d4111803e9a690658aa2e6366384fd0851064b963b6d1f2a7"},
+    {file = "protobuf-5.29.3-cp39-cp39-win_amd64.whl", hash = "sha256:6ce8cc3389a20693bfde6c6562e03474c40851b44975c9b2bf6df7d8c4f864da"},
+    {file = "protobuf-5.29.3-py3-none-any.whl", hash = "sha256:0a18ed4a24198528f2333802eb075e59dea9d679ab7a6c5efb017a59004d849f"},
+    {file = "protobuf-5.29.3.tar.gz", hash = "sha256:5da0f41edaf117bde316404bad1a486cb4ededf8e4a54891296f648e8e076620"},
 ]
 
 [[package]]
@@ -1738,13 +1738,13 @@ files = [
 
 [[package]]
 name = "pydantic"
-version = "2.10.4"
+version = "2.10.5"
 description = "Data validation using Python type hints"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pydantic-2.10.4-py3-none-any.whl", hash = "sha256:597e135ea68be3a37552fb524bc7d0d66dcf93d395acd93a00682f1efcb8ee3d"},
-    {file = "pydantic-2.10.4.tar.gz", hash = "sha256:82f12e9723da6de4fe2ba888b5971157b3be7ad914267dea8f05f82b28254f06"},
+    {file = "pydantic-2.10.5-py3-none-any.whl", hash = "sha256:4dd4e322dbe55472cb7ca7e73f4b63574eecccf2835ffa2af9021ce113c83c53"},
+    {file = "pydantic-2.10.5.tar.gz", hash = "sha256:278b38dbbaec562011d659ee05f63346951b3a248a6f3642e1bc68894ea2b4ff"},
 ]
 
 [package.dependencies]
@@ -1949,13 +1949,13 @@ tests = ["coverage[toml] (==5.0.4)", "pytest (>=6.0.0,<7.0.0)"]
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.13"
+version = "10.14"
 description = "Extension pack for Python Markdown."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pymdown_extensions-10.13-py3-none-any.whl", hash = "sha256:80bc33d715eec68e683e04298946d47d78c7739e79d808203df278ee8ef89428"},
-    {file = "pymdown_extensions-10.13.tar.gz", hash = "sha256:e0b351494dc0d8d14a1f52b39b1499a00ef1566b4ba23dc74f1eba75c736f5dd"},
+    {file = "pymdown_extensions-10.14-py3-none-any.whl", hash = "sha256:202481f716cc8250e4be8fce997781ebf7917701b59652458ee47f2401f818b5"},
+    {file = "pymdown_extensions-10.14.tar.gz", hash = "sha256:741bd7c4ff961ba40b7528d32284c53bc436b8b1645e8e37c3e57770b8700a34"},
 ]
 
 [package.dependencies]
@@ -1963,7 +1963,7 @@ markdown = ">=3.6"
 pyyaml = "*"
 
 [package.extras]
-extra = ["pygments (>=2.12)"]
+extra = ["pygments (>=2.19.1)"]
 
 [[package]]
 name = "pyparsing"
@@ -2049,28 +2049,28 @@ pytest = ">=4.2.1"
 
 [[package]]
 name = "python-box"
-version = "7.3.0"
+version = "7.3.1"
 description = "Advanced Python dictionaries with dot notation access"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "python_box-7.3.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a2131477ed02aa3609b348dad0697b70d84968d6440387898bb9075f461ef9bf"},
-    {file = "python_box-7.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3284cf583476af63c4f24168b6e1307503322dccd9b3dc2c924f5e69f79e7ab5"},
-    {file = "python_box-7.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:2718cf4c8dcc091d1c56a1a297804ab7973271391a2d2d34d37740820bbd1fda"},
-    {file = "python_box-7.3.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:e40fe08b218b3d07a50d6eb1c62edce8d0636d6bd1e563907bc86018a78e5826"},
-    {file = "python_box-7.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd13e2b964ed527e03409cb1fb386d8723e0e69caf0f507af60d64102c13d363"},
-    {file = "python_box-7.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:d661fb9c6ff6c730b53fe859754624baa14e37ee3d593525382b20194efad367"},
-    {file = "python_box-7.3.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:6c3809f78f7c829e45626990a891d93214748938b9c0236dc6d0f2e8c400d325"},
-    {file = "python_box-7.3.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c233b94bf3b95d7d9dc01ed1ee5636800174345810b319eb87219b760edbb54f"},
-    {file = "python_box-7.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:9a22cc82e78225a419c4da02f53d6beb5c5cbd2fe5f63c13dab81e4f27b8c929"},
-    {file = "python_box-7.3.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:1f7b93c5ab4027b12ba67baffa8db903557e557250e01b91226d7a1b9688cf77"},
-    {file = "python_box-7.3.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:71ed234c1cff7f7197103bb11d98559032c0beac34db0c62dd5bd53e2b2a6963"},
-    {file = "python_box-7.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:1144c9e5d40a2cbe34d1ec9a13abfc557e8e9e2fbf15f14314c87b6113de178f"},
-    {file = "python_box-7.3.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:df77730baabf45b1682ead1c470e84a530f8ceb0295263a89f0ebc04ef7f363c"},
-    {file = "python_box-7.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:36bef944e61672b300c1d56d16db8a43ee4af9ab5678492a5e003368d2c64a6e"},
-    {file = "python_box-7.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:b35a2262a4e1ccfba90ce8e2018aa367f8a46a519632884006fa3153b266f184"},
-    {file = "python_box-7.3.0-py3-none-any.whl", hash = "sha256:b1139bffe91bd317fd686c4c29ffc84115c1967af14112c5c4a8ac51937d530c"},
-    {file = "python_box-7.3.0.tar.gz", hash = "sha256:39a85ba457d07122226ca60597882d763549713ab56ac7d55da41c4ad0e89a05"},
+    {file = "python_box-7.3.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:fadf589c5d37d5bf40d25f6580d500168f2fc825d2f601c25e753ffc8d4bbec0"},
+    {file = "python_box-7.3.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d375605b159c174b0d60b6acb3586bc47ba75f542b614e96fac2ef899c08add8"},
+    {file = "python_box-7.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:f7fef93deb2695716218f513cc43e665f447a85e41cf58219e42e026c570bd67"},
+    {file = "python_box-7.3.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7cdcc0585d5840a04a74e64301d4ec5b0a05bc98a305d0f9516d3e59d265add1"},
+    {file = "python_box-7.3.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7aa85d0f1f0ea1ef4af33c0f3a133b8cec8f0ad3bfd6868370833efb8b9f86b3"},
+    {file = "python_box-7.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:6fd0463e20a4c990591094fbb0f4e3b39f8212d1faf69648df4ffac10912c49e"},
+    {file = "python_box-7.3.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3320d3fa83f006ae44bda02f9ee08647ed709506baf5ae85be3eb045683dd12b"},
+    {file = "python_box-7.3.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6277ef305fb1cc75e903416e0b4f59952675d55e8ae997924f4e2f6e5abf61b"},
+    {file = "python_box-7.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:34d409137b41c15322491f353c331069a07d194573e95e56eae07fe101c04cbe"},
+    {file = "python_box-7.3.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e5e0c2bf73ab1020fc62f2a7161b8b0e12ee29872292ec33fb8124aa81adb48e"},
+    {file = "python_box-7.3.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2fe1e1c705535ec5ab9fa66172cf184a330fd41638aaf638a08e33a12c7c3f71"},
+    {file = "python_box-7.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:4fccc0b218937a6254219073f945117978f5222eff1bbae8a35b11c6e9651f5d"},
+    {file = "python_box-7.3.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:a48050391cb4d8dcec4b0f8c860b778821ae013a293d49f0cbaeab5548c46829"},
+    {file = "python_box-7.3.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a5bf3264cd4ee9b742aefadb7ff549297dd7eef8826b3a4b922a4a44e9b0751"},
+    {file = "python_box-7.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:0ed2024e27d67c5cf1ed1f88d8849aace9234d7a198fd4d5c791ed12e99e7345"},
+    {file = "python_box-7.3.1-py3-none-any.whl", hash = "sha256:2d77100d0d5ad67e0d062fac4f77f973851db236f4a445c60b02d0415f83b0d6"},
+    {file = "python_box-7.3.1.tar.gz", hash = "sha256:a0bd9dbb4ddd2842f8d0143b8aa0c87d0e82e39093dd4698a5cbbb2d2ac71361"},
 ]
 
 [package.extras]
@@ -2251,76 +2251,102 @@ prompt_toolkit = ">=2.0,<4.0"
 
 [[package]]
 name = "reclass-rs"
-version = "0.5.0"
+version = "0.6.0"
 description = "Reclass defines a syntax and directory structure for recursively merging YAML data sources."
 optional = true
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "reclass_rs-0.5.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:ec27d13f2bd1fe9415c0dc2bdf7f917747fb0555395e23dc46e5022b03ac3d0d"},
-    {file = "reclass_rs-0.5.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6cd48c874904b848748e828cfe94d63ca472c5632a9d21d42a47137dfb6b0f68"},
-    {file = "reclass_rs-0.5.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da4d66d0fec4d7595376f8f908f3ac8f7654513cce551696f5817387b863e555"},
-    {file = "reclass_rs-0.5.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:91484388c652e5bfaba2ecb33a05141d20b3c5c72f63c560eb5aad5f8e3e53d2"},
-    {file = "reclass_rs-0.5.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a8c0f5564c5eaaa6855048907a8c6f8a7b9c73a8906211d82b68a9dd4e34a171"},
-    {file = "reclass_rs-0.5.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9c200c25e792afc395864b7db835e721c7998d47d8c535cf39ae10479f223ed6"},
-    {file = "reclass_rs-0.5.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:12df412a5851c98acdccbe82d665857a5097008a730257e1c2c38c580484ae15"},
-    {file = "reclass_rs-0.5.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c7c6d055e8c9a58ebd6d9977136f6acac076afa9539c89c61c552cd70a57926"},
-    {file = "reclass_rs-0.5.0-cp310-none-win32.whl", hash = "sha256:9c2d15d4f85a19a3f9ed3a0d35c15c9c6296636d5390086ad6b7ed3afc75277b"},
-    {file = "reclass_rs-0.5.0-cp310-none-win_amd64.whl", hash = "sha256:656100c7007944f8c74fd282716294fac410bc9454286244300a61085c5f0693"},
-    {file = "reclass_rs-0.5.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:7f67f3ea8b4ae13a6714f5d860d12a5f4a65777109c3b4222e4f5c71ee17081d"},
-    {file = "reclass_rs-0.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b80fbaec164109d8d1b18f96149f1452000756247bb5575e1fa9f13367b844fb"},
-    {file = "reclass_rs-0.5.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3083a72e95cd73ef95be4aff86ed4e9ec7aa5c6692415427b5eba7f532628970"},
-    {file = "reclass_rs-0.5.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d14dd9282b1e70a173221a7d2c324068b5e1728e58ce9fe273c944f9885bb93b"},
-    {file = "reclass_rs-0.5.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:63ac0e34af94c04bd188d07e875f6ec60218547774ddb52fd8927640d9dd87b8"},
-    {file = "reclass_rs-0.5.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b618877fdfb416e35b87ee3a7122d693ab88985c5bb3c85161f9ca24a52fdb11"},
-    {file = "reclass_rs-0.5.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:03918a094cbd611c0aef0ad00da3d7756d977326c9e4dcc9052b10a4cef5f0cf"},
-    {file = "reclass_rs-0.5.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:36af3b8a00610e520fbd31e8401e339babc35c73214608726929e6ab905e3f4e"},
-    {file = "reclass_rs-0.5.0-cp311-none-win32.whl", hash = "sha256:9f67b3fd95f03e98db4916396c06703e6f07aa5606dbee01221cae4a64778d7d"},
-    {file = "reclass_rs-0.5.0-cp311-none-win_amd64.whl", hash = "sha256:0b79f2174f75bad8ee850921c8e93df5c050565251060864ad2688ab39d20fa5"},
-    {file = "reclass_rs-0.5.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:c6133a5ed6fcd52ab3176a630690366ba3d7d080c0b39d14c087ac962d99c24c"},
-    {file = "reclass_rs-0.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d3cb13b87d71b3df81057ca67c6834418f121c9135ca30b438abbdbf8adf4863"},
-    {file = "reclass_rs-0.5.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f194ffd8b65e3ddf13ac954445e17d799cb882c39a5b25da770b926e65f0b08f"},
-    {file = "reclass_rs-0.5.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:dfc5fe01bc794b99db1a717f9731733460cf4c2fb10a5069bf690dfdb6ba4532"},
-    {file = "reclass_rs-0.5.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:96b1a7c97f10668700d696ac07b7ee100b7cd9245331645920866e272a9ae39c"},
-    {file = "reclass_rs-0.5.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a4ddf1911aab30b03c1a61f6f96b63619a5d0c54c41c94e5b8419de457f27b9e"},
-    {file = "reclass_rs-0.5.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5cd9fcf86b5b1910cc71136c766b42d41d9d1fe43114c3219034bbcddcf7e3f9"},
-    {file = "reclass_rs-0.5.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:02b36b0bbbd6393c1ffef6810930b3f96b0d5f4248346943996434e9ccade546"},
-    {file = "reclass_rs-0.5.0-cp312-none-win32.whl", hash = "sha256:1f04c3c939ffcd5bc15c618b5af87f06be03d007a3049c4ee5277aca89a99b5b"},
-    {file = "reclass_rs-0.5.0-cp312-none-win_amd64.whl", hash = "sha256:4d9430bbd1b8ff57d5a1c3a1558424dc1bd3391576ee2f003b84a3a613ae866c"},
-    {file = "reclass_rs-0.5.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa24ecec09c6762ca33bbf7f15d7f0b98efa87d4f76cfd361a6bf85376f81da6"},
-    {file = "reclass_rs-0.5.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4d8b50e97f9cdc1ee7bf426726d941b128548a244a2e7e171d1692156b22dff0"},
-    {file = "reclass_rs-0.5.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2fe724f61522e37fd3b124a43ac7c5876fe6e6418252f983a420f27192079eb9"},
-    {file = "reclass_rs-0.5.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fcf016f0b487297a4a1e115702cb673e077d320a53ab2bc514d6206c155c1c5c"},
-    {file = "reclass_rs-0.5.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9a9f648aa1267a3c464811edca6a28343f8459767dd50367e0b0358a32733a2e"},
-    {file = "reclass_rs-0.5.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cbecf72aa58f087d57c557a9ee689c723bf79faa485c90c081f6231b2b545747"},
-    {file = "reclass_rs-0.5.0-cp38-none-win32.whl", hash = "sha256:e8404f1ab88a5894611918698017520693dc5d5d88aae9549ca69f39f2fdcf7f"},
-    {file = "reclass_rs-0.5.0-cp38-none-win_amd64.whl", hash = "sha256:a22ebb7170d6fff49713ad3e2df038b6b7ce6c13726e850cdca5e7cdf1c27f0e"},
-    {file = "reclass_rs-0.5.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:8cd6bdd13c93550e7eb607c1eebe43d6f0b886f76808364365fb01cf510de621"},
-    {file = "reclass_rs-0.5.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:04f62e005bfe1c8908f17142e08f5cf6b2a1a71701a491a8942f1e6c40685145"},
-    {file = "reclass_rs-0.5.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9876fdffd99a42d4718f7fd04cf129c5ef758db68719c1f4ba4887323260e267"},
-    {file = "reclass_rs-0.5.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d228162d32573aba503e91d77d1275ff52036827e3f7e98eaf433c15aea50e8d"},
-    {file = "reclass_rs-0.5.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:21f1b7ff68cd3bd5407c4e19e739fb15cf8df0ebde48611c1f4dea270300a3d4"},
-    {file = "reclass_rs-0.5.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ea99e51e4509f6d7b8c8df20c8b4888175cfe9e2d8178c003eae183759efd297"},
-    {file = "reclass_rs-0.5.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cf6d227ef20d1651625ff4436358d7b951a68d2dfb9f7a62491c7b45ab6d9594"},
-    {file = "reclass_rs-0.5.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cb50973ca2957e03be8675a8846dd84dd431310b8060c2f63559c984f7f3f5e1"},
-    {file = "reclass_rs-0.5.0-cp39-none-win32.whl", hash = "sha256:cd18d6c20b0f715c9731a1c81397b73cc8857d120c2537001ea13a7068c2ecde"},
-    {file = "reclass_rs-0.5.0-cp39-none-win_amd64.whl", hash = "sha256:c87fad930131ddc2b55e5183e0283d9dd9173d0cfc451b96bda3f29f437fc2c1"},
-    {file = "reclass_rs-0.5.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef377173244955f17d70432abef68a37a25521ad88ff1d6c51e66f28308dd6bf"},
-    {file = "reclass_rs-0.5.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d3741965729bf3439bc9fa63920426eb028eaad60f2615875cfd055110abeb94"},
-    {file = "reclass_rs-0.5.0-pp310-pypy310_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:07cd36e14a2a998321e0b23e61f6aa9b0d46ff0158b55f5269cae78dbb61c052"},
-    {file = "reclass_rs-0.5.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f1c3496428ba4837676ae1088153da9ed6275dc57b802f78838147968baed6f4"},
-    {file = "reclass_rs-0.5.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:18169857dbd8419ac7b5e0e8c86a230901b8bcbc5e25d93d27912e00c690a7e7"},
-    {file = "reclass_rs-0.5.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e20e20092a9b074b13592f4c6e7f02a68c20e3ad6f0bd35b3af5e96b922b545f"},
-    {file = "reclass_rs-0.5.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa5fad27333c625292cb5f3ecd63166528e35dae1be30c67d86b3910ca9ff0a3"},
-    {file = "reclass_rs-0.5.0-pp38-pypy38_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:10e50f05fad937741f0a598e7265299338a7b413054eb36263b81442aba6ee7c"},
-    {file = "reclass_rs-0.5.0-pp38-pypy38_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7eaf0f0b9eae770e42bfb10a84b66abf99aae3ad7c2a51a44004283587722bc3"},
-    {file = "reclass_rs-0.5.0-pp38-pypy38_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c4fef3e0ea2c52934fa7ef46608676609e59a78ae4a72e7cb0b8023461874776"},
-    {file = "reclass_rs-0.5.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:53cf888e3165fe70b3d74efe136fc5a0e5fe3f06a9d4a422e06d83a26e8bd1ae"},
-    {file = "reclass_rs-0.5.0-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:13b891fffc255e0cc7055857df9598dd6d8c9cf6fafe735f4bfb6ffc487994d8"},
-    {file = "reclass_rs-0.5.0-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:63676dd228f331023a83d7b9442958b36e02bd48889c60da877b6141e5f1a9c6"},
-    {file = "reclass_rs-0.5.0-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b72a841202f7623c8fe49186ba768c466286ad42f3879cd569cd82c8b4a90011"},
-    {file = "reclass_rs-0.5.0-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a82e42022bbcb7a787700bf7121a0e7737416ff744a54b8435fa3671e5d6d480"},
-    {file = "reclass_rs-0.5.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:07864b9c40e176f03bb6117efda5323831b3262a6d3d2b8cb55de6a3e6421dd3"},
-    {file = "reclass_rs-0.5.0.tar.gz", hash = "sha256:afba73a352a99a738e760c223c346589767e22df07736d6e90beb0ae847babf8"},
+    {file = "reclass_rs-0.6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d025c92bffc09d893397301f3d31507a654a0e336d560f268e0fe668d691e676"},
+    {file = "reclass_rs-0.6.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:22d3196369687c689067c2cc7ef10fcda256a21bdfbabdf2fa9071ac759ac3b0"},
+    {file = "reclass_rs-0.6.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0e88b4d42049642a8e7ece15a8660b886614262cd6ef2cdf12215a01c49a7fe0"},
+    {file = "reclass_rs-0.6.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:42ac95d8df3b821bfb4a243e1c5ca8f5458d80fab925e61ed1e842a2b9e7b86e"},
+    {file = "reclass_rs-0.6.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0a34d3301d24dd6b48c141aafdf6a882cdde50427861ccb38e9f84be31b2b0a7"},
+    {file = "reclass_rs-0.6.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b587c084db9380aa34586a29567947bc2e0359f0bd74c57b0f0230de00789f14"},
+    {file = "reclass_rs-0.6.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:82aca2da90703fa2869b2a3c6a9725bf90465e2a635e0eec38552ed40a275808"},
+    {file = "reclass_rs-0.6.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:2c8b1e64f80babc324a6c188216d91f5fd099a75d232aaf2c29c71a1c3e4506f"},
+    {file = "reclass_rs-0.6.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:d74fe17bd0dc09ccbfff2a021ab0c7f60ed1fccd37fbf045e19e38b0a131d47a"},
+    {file = "reclass_rs-0.6.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:304086881a9be6cf10116dff91311dbe65635f53540ed2b4d0e557f0e3f75736"},
+    {file = "reclass_rs-0.6.0-cp310-cp310-win32.whl", hash = "sha256:56e5b837fe82760ec3dfbb4796c9fe6a889110371fcc2c19b54ea91f38a2ab04"},
+    {file = "reclass_rs-0.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:ebe49d3a7d8ca4c318cd2b6940884455a26b557bcf0d8113180275d293021647"},
+    {file = "reclass_rs-0.6.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:026aff8c9ed51f4a2aa68e74cacf26d5a47ed8a610ca9157ef1ae3e243a257a2"},
+    {file = "reclass_rs-0.6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e244eec3892cb449afcc7952df27892a814ba9816aa6777e2a041f32c20375c3"},
+    {file = "reclass_rs-0.6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f519f46954e0f7b580b63812201446f015a8026419289b6ff148b8d1bf4a163a"},
+    {file = "reclass_rs-0.6.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7d3992c580429ccc0bcab430c31b6ffb6a69106b320a731e4883ec9b005a740a"},
+    {file = "reclass_rs-0.6.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b52038d6361fd8211d5d43f245b2176fbd1f115503c5ba6903e5a2976098e3cb"},
+    {file = "reclass_rs-0.6.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c726dba36fd136144021c2064cd6f638f735aefa67ca6b4e288f86f86d03ea9c"},
+    {file = "reclass_rs-0.6.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cac1f795fc0fb2c089af1de215e976e4bf72430b36b94e8fa20ccedabbdc6cf7"},
+    {file = "reclass_rs-0.6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a15713497527c394c9b3827f7efd24bc8cad0041efb50e74336f2d70c9c9f47"},
+    {file = "reclass_rs-0.6.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a4ad6d3f9ee271e80d9f14fe30bb63769eef8a8977ab32e3a2fc351507b849ff"},
+    {file = "reclass_rs-0.6.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:09764ce8489acf034b11d83dcee62ab364435155e104963404cc1fc2594b44d0"},
+    {file = "reclass_rs-0.6.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:a71e56944c5b1385cc2057d0e148419cedc53feda2daff46ccb99e97c3171c15"},
+    {file = "reclass_rs-0.6.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:dc1d0813b8cdfeeddeee8dd0b578e3f84528ef93ca08e32a5ea7a9308818230d"},
+    {file = "reclass_rs-0.6.0-cp311-cp311-win32.whl", hash = "sha256:aa320cc76d3b1dd7097ab5862979e0b898eb9df22802bf1cd2da816c92e7e2d7"},
+    {file = "reclass_rs-0.6.0-cp311-cp311-win_amd64.whl", hash = "sha256:ffbe15ffa6f5edcae422553d2df0aa6ae4a304722b0bdd309ecf8f8c9ab7d8ae"},
+    {file = "reclass_rs-0.6.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:05f9be87d6aa99bc32f4a68051359f8976385e3ac9b3a5ec95bdbd3804e1f0d0"},
+    {file = "reclass_rs-0.6.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0ce53491f708e8b09466b45a346b244224daf0531495f13b49d010c0b9362651"},
+    {file = "reclass_rs-0.6.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6d4bb9f87483df9938a54a8da11cfc4ade80494057f1f1ed6d43cf642e1bdb5b"},
+    {file = "reclass_rs-0.6.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29d9cf1337b239ac8af2c45653fb83c85c87540baaee1cabbf80e9b5d768482d"},
+    {file = "reclass_rs-0.6.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fb4d1cffebb3a79ba9aa92357621f33c16ddcb4ed1e9d54c45260f4c02009570"},
+    {file = "reclass_rs-0.6.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8fa8c48058a5fdaa8447f88eb7da6d2e1c5168579fcaaca43b1a9c8a124c3172"},
+    {file = "reclass_rs-0.6.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9774e76a21b670996437eecb4d4b59ccbbb0b4a5a0dc527ea2c5121f1bae9e8f"},
+    {file = "reclass_rs-0.6.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b084ff6b4e0a04d265cba4d183bb6add2767e6b0384601f80e6d6a27f17c93f6"},
+    {file = "reclass_rs-0.6.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:03b6a4b675e93e785614862c4d52ca629a1e5e75ca9217ed4e66ae17c08e4aab"},
+    {file = "reclass_rs-0.6.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:47feb9e6360456cf707c3da56cfb9ce668cfba89e01a31df351cec00c9d449cc"},
+    {file = "reclass_rs-0.6.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:c0870aaf9160dc365533696d3b939ae853c172cddabe8f2c8fcea8e9a244683d"},
+    {file = "reclass_rs-0.6.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:394e2f068309af37c39f666d27691b89d09998bde216d78d64e49fcc263059da"},
+    {file = "reclass_rs-0.6.0-cp312-cp312-win32.whl", hash = "sha256:abc8680ba1d81b088b08a6273855a9dec30f80a4ff807bdc63419740821cc827"},
+    {file = "reclass_rs-0.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:428dc699aa4b0a0e02e3da7bf322e471020b525c423362e62eb6fac6000f33a2"},
+    {file = "reclass_rs-0.6.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5f87c19b149605c17451fce7d6fdf0c65e807c05462b535caea17ad3f6ff60d6"},
+    {file = "reclass_rs-0.6.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:84527c13042bd260da534609e90c1cdfcfcafeacee6599442d3cb5e42989480c"},
+    {file = "reclass_rs-0.6.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5938f8001ab2e80bf08a5d6e7eb238059e0ca46109ad76b4af5a90b03dac013"},
+    {file = "reclass_rs-0.6.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:23e9098826c517d0a6d5fd3bdc31b991f9c48610be3803d75f27e3ad9403f85c"},
+    {file = "reclass_rs-0.6.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:93fdaebbe7d1b7f53e8f99052ebf6c004a59230deee1cea2aaeddc7b2ecec5a1"},
+    {file = "reclass_rs-0.6.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f73e24e5a0466f784c700f66ed5eee50dcbaffbe1d39042cef33c901f79c609"},
+    {file = "reclass_rs-0.6.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6a3cd22ef1bf7e8ae99e21a51fd9925f869e8359efc7a4e6a6accc07424a5848"},
+    {file = "reclass_rs-0.6.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17b7ef57cc02cf03476689d22ea9c3c55d0005161cbdf1136626d29bf52abcc6"},
+    {file = "reclass_rs-0.6.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a2f6f5f122d47a2c9bd35e245b9814b816eb08c22e4bd4ba6b38e28f26686286"},
+    {file = "reclass_rs-0.6.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:94e6b9b930c06014eafbeb047f8867522a218a69699c9c8ad4cf0fe43291dad6"},
+    {file = "reclass_rs-0.6.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e66857d88fd739c7e48f93e2c08d65197d86cd019529ea1883e46864dfa163ed"},
+    {file = "reclass_rs-0.6.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:743d26ccde1563800c16f9f25624647c86b433382320d8849e5e7042dccefe67"},
+    {file = "reclass_rs-0.6.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ecca5c181449cd40943d0c1a3c1a5fd135fb17236eb42e8cecc0a23b7763aa01"},
+    {file = "reclass_rs-0.6.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4fe2d90bd9ec676f1eaf5ddda19a1a69508da7e42a450e0aec43551863de0705"},
+    {file = "reclass_rs-0.6.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:29b9893c3b3bbe81810272c47c1a65911162b8ff9cd8ffd0ba8ce254c1367c4c"},
+    {file = "reclass_rs-0.6.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bc576ff0aa4370877b1cef716fe74a0abad98c9340d4c0ed8c2449c21da41552"},
+    {file = "reclass_rs-0.6.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:0d57aafc832fbd354eeb22c43f0ed069574851b57c56b8a605989bc7629da1aa"},
+    {file = "reclass_rs-0.6.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:80f3845855183005a8c004c3f6efa8c1248cf705455677fe24755633e8cded75"},
+    {file = "reclass_rs-0.6.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:9eaeb6bda36fcfd8bec6e514377ca87dcdccfc1832e8df1a00369a90511e450d"},
+    {file = "reclass_rs-0.6.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:80142091554bde25cb0a3f0244a21ef4d958a45e83599b5ebe02dffb81491944"},
+    {file = "reclass_rs-0.6.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:81c5b64ce3f2d39d8fd695253f89357d357f92d3221134c88b84f3b4d948fd7c"},
+    {file = "reclass_rs-0.6.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:51515d2aa9c1cd1048a74cb83983fe96d9a40c07a9351187a3ee7f52e1af714a"},
+    {file = "reclass_rs-0.6.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7af768321138fa842962243e60d02c7a943daa5982e54b70989bcc686849d10a"},
+    {file = "reclass_rs-0.6.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:df6f83ce26e3cafb304630a873d1a05c7ba2645d90a5e1013daae9117d5464f9"},
+    {file = "reclass_rs-0.6.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c8046a09159b8467d0faa3ebf1699b541c0b2b9fc6795939bf3a0b4144cce691"},
+    {file = "reclass_rs-0.6.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:294eb2cc9cea4e140581a1b8bf339e8457d2118d3f14bfbc47ae2cb242d3ec3a"},
+    {file = "reclass_rs-0.6.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:4fc52909200417e7cf2ff85d1dae13c463c12a7d57f77a492649ac65b9de7210"},
+    {file = "reclass_rs-0.6.0-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:a1610e21f2bd8b6c2f9aff0ae4dd1f339a088ddbc51f83c4d6ab29b68473b130"},
+    {file = "reclass_rs-0.6.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:b9818f6aaf55b4b47e424bcb5e7b19dc972ef19e83260aa6106b23156d87336d"},
+    {file = "reclass_rs-0.6.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:03ab116e19e5dc000835c792b7715dac5cd02dc015dd91d9990a9678a221ab0e"},
+    {file = "reclass_rs-0.6.0-cp39-cp39-win32.whl", hash = "sha256:fb17501b3dffd73b5bd0f63f503ccf13a2387ff3d14bf4a3d943b337fab46cbe"},
+    {file = "reclass_rs-0.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b77b356e5a431ed27579a2319f55c99fd9962a7c4b10fcb1affbd3af917d6958"},
+    {file = "reclass_rs-0.6.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55667eedf2a7531a7fe3cbe2f306c62261229e5b7f7cde3ed053b48398dbb88c"},
+    {file = "reclass_rs-0.6.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9c15021a1dc2d36933f6d1f86ccfb70da6ac1422163e2a964f51ec8f875c7bd1"},
+    {file = "reclass_rs-0.6.0-pp310-pypy310_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ccb45ef29728ef87c5b5106e6ccbec718d20d8dd0e41bb986d8eaeaf75eb98b0"},
+    {file = "reclass_rs-0.6.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a56f5078c9d20253fe0e878595fcd46705bb71a701ca17db659ac28dee389c1a"},
+    {file = "reclass_rs-0.6.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b9a2b3b01cd9574c6ef690f4c331fcf287b3e9e99315c32dbed0f6d12371674"},
+    {file = "reclass_rs-0.6.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7fbd6887bc33173707c6193e15d38a0cf061a03c92a6940cb099a333902899e5"},
+    {file = "reclass_rs-0.6.0-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:7e3f35659623fab4a62134bec2b19c5df44f3f74aad457d9fd9d373c5c35a509"},
+    {file = "reclass_rs-0.6.0-pp310-pypy310_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:664c72181ed43a59921e9661c287a350fcd80f9f4d84e6d3f160b4509e1c7471"},
+    {file = "reclass_rs-0.6.0-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:f528a7642f9ed4f59c0f78edd42fd45746dc004e0d4c302288fdaa304757c83d"},
+    {file = "reclass_rs-0.6.0-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:13f74939df62f573d20a6ee0a50367c301106f5e93569b9203b59815708526fc"},
+    {file = "reclass_rs-0.6.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:22c597f6eae75aee67d3c4dccd70be1d2b717316a8462862b257772c7aa6d6dd"},
+    {file = "reclass_rs-0.6.0-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:84c2af332e4377d7469a671ef772c3b217afbb2ee667eef382f031c165be3877"},
+    {file = "reclass_rs-0.6.0-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4a3f3189a3a7d5df65c833a1c4dfa256b1953aa423a3f6e61fb68d462c963982"},
+    {file = "reclass_rs-0.6.0-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9c698d64df06f258d22adcfbb55beacff4bc0c61d02a0fd12e8c7c227c29a89b"},
+    {file = "reclass_rs-0.6.0-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:4a150eb86118467b5524359437ac6985747bc151304aaeeefd0e041193748e23"},
+    {file = "reclass_rs-0.6.0-pp39-pypy39_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:43fc252ce1ce9fd5c5f07c5bc24aa943935a1e8120efefdde1f1a65ec56fd8dc"},
+    {file = "reclass_rs-0.6.0-pp39-pypy39_pp73-musllinux_1_2_i686.whl", hash = "sha256:73fe8ff78caa3e4c00fa42306520abdeef72265ddd69cb4341cc991c79428094"},
+    {file = "reclass_rs-0.6.0-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:6b8bb5a28dafd4d72957abf6ed9ca6bbed530ed853d373d2592341e9e66c03a4"},
+    {file = "reclass_rs-0.6.0.tar.gz", hash = "sha256:c4e85e9402486d42c729151631aa88b6411fc2c2a34ef2a45baf2f95a0ed171b"},
 ]
 
 [[package]]
@@ -2590,13 +2616,13 @@ pyasn1 = ">=0.1.3"
 
 [[package]]
 name = "s3transfer"
-version = "0.10.4"
+version = "0.11.0"
 description = "An Amazon S3 Transfer Manager"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "s3transfer-0.10.4-py3-none-any.whl", hash = "sha256:244a76a24355363a68164241438de1b72f8781664920260c48465896b712a41e"},
-    {file = "s3transfer-0.10.4.tar.gz", hash = "sha256:29edc09801743c21eb5ecbc617a152df41d3c287f67b615f73e5f750583666a7"},
+    {file = "s3transfer-0.11.0-py3-none-any.whl", hash = "sha256:f43b03931c198743569bbfb6a328a53f4b2b4ec723cd7c01fab68e3119db3f8b"},
+    {file = "s3transfer-0.11.0.tar.gz", hash = "sha256:6563eda054c33bdebef7cbf309488634651c47270d828e594d151cd289fb7cf7"},
 ]
 
 [package.dependencies]
@@ -2768,13 +2794,13 @@ test = ["coverage", "flake8 (>=3.7)", "mypy", "pretend", "pytest"]
 
 [[package]]
 name = "virtualenv"
-version = "20.28.1"
+version = "20.29.0"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "virtualenv-20.28.1-py3-none-any.whl", hash = "sha256:412773c85d4dab0409b83ec36f7a6499e72eaf08c80e81e9576bca61831c71cb"},
-    {file = "virtualenv-20.28.1.tar.gz", hash = "sha256:5d34ab240fdb5d21549b76f9e8ff3af28252f5499fb6d6f031adac4e5a8c5329"},
+    {file = "virtualenv-20.29.0-py3-none-any.whl", hash = "sha256:c12311863497992dc4b8644f8ea82d3b35bb7ef8ee82e6630d76d0197c39baf9"},
+    {file = "virtualenv-20.29.0.tar.gz", hash = "sha256:6345e1ff19d4b1296954cee076baaf58ff2a12a84a338c62b02eda39f20aa982"},
 ]
 
 [package.dependencies]
@@ -2884,4 +2910,4 @@ reclass-rs = ["reclass-rs"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10,<3.13"
-content-hash = "fa9ba96328bed41686e65fd1ac0bac64d0cfd6165b987fddc389250b6cee9fdc"
+content-hash = "3d358643407855d1fd8a151a10983c87bfca58aaa437e21344d70ffc6f68d793"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ typing-extensions = "^4.0.0"
 kadet = "^0.3.0"
 regex = "^2024.5.10"
 omegaconf = {version = "^2.4.0.dev3", optional = true}
-reclass-rs = {version = "^0.5.0", optional = true }
+reclass-rs = {version = "^0.6.0", optional = true }
 gojsonnet = { version = "^0.20.0", optional = true }
 kapicorp-reclass = ">=2.0.0"
 pydantic = "^2.8.2"


### PR DESCRIPTION
Fixes https://github.com/projectsyn/reclass-rs/issues/148 -- reclass-rs didn't discover targets in subdirectories of `inventory/targets` without compose-node-name (e.g. when compiling the kapitan-reference repo).

## Proposed Changes

* Update reclass-rs to `^0.6.0`

## Docs and Tests

* [ ] Tests added
* [ ] Updated documentation
