### PR TITLE
Correct label for python version in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -79,6 +79,7 @@ body:
         Which version of python are you using? Kapitan officially supports only version 3.10 and 3.11
         If you are using an older version of python, please check if the bug still exists with a newer (supported) version.
       options:
+        - "3.12"
         - "3.11"
         - "3.10"
         - I use kapitan directly (pip, docker)

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -74,7 +74,7 @@ body:
   - type: dropdown
     id: python-version
     attributes:
-      label: Version (kapitan)
+      label: Version (Python)
       description: |
         Which version of python are you using? Kapitan officially supports only version 3.10 and 3.11
         If you are using an older version of python, please check if the bug still exists with a newer (supported) version.


### PR DESCRIPTION
Previously, the label of the `python-version` field was also "Version (kapitan)".
