### PR TITLE
remove duplicate inventory error

### DIFF
--- a/kapitan/resources.py
+++ b/kapitan/resources.py
@@ -311,9 +311,7 @@ def generate_inventory(args):
         else:
             yaml.dump(inv, sys.stdout, Dumper=PrettyDumper, default_flow_style=False, indent=args.indent)
     except Exception as e:
-        if not isinstance(e, KapitanError):
-            logger.exception("\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
-        sys.exit(1)
+        raise
 
 
 def get_inventory(inventory_path, ignore_class_not_found: bool = False) -> Inventory:
@@ -347,7 +345,7 @@ def get_inventory(inventory_path, ignore_class_not_found: bool = False) -> Inven
             ignore_class_not_found=ignore_class_not_found,
         )
     except InventoryError as e:
-        raise
+        sys.exit(1)
 
     cached.inv = inventory_backend
     cached.global_inv = cached.inv.inventory

--- a/kapitan/resources.py
+++ b/kapitan/resources.py
@@ -340,7 +340,6 @@ def get_inventory(inventory_path, ignore_class_not_found: bool = False) -> Inven
     backend = get_inventory_backend(backend_id)
 
     logger.debug(f"Using {backend.__name__} as inventory backend")
-
     try:
         inventory_backend = backend(
             inventory_path=inventory_path,
@@ -348,7 +347,6 @@ def get_inventory(inventory_path, ignore_class_not_found: bool = False) -> Inven
             ignore_class_not_found=ignore_class_not_found,
         )
     except InventoryError as e:
-        logger.fatal(e)
         raise
 
     cached.inv = inventory_backend


### PR DESCRIPTION
Reduce duplicate error messages from inventory errors. Each of the backends already print out the errors. example:
https://github.com/kapicorp/kapitan/blob/master/kapitan/inventory/backends/reclass/__init__.py#L59

Also changed exit point for kapitan inventory errors
    
better to exit at `get_inventory` instead of `generate_inventory`.
    
- "kapitan inventory" calls generate_inventory which then calls get_inventory
- "kapitan compile" calls get_inventory
    
Best to exit at the function that's common for both


# TEST

kapitan/examples/kubernetes/inventory/targets/labels.yml

```
classes:
  - common
  - component.namespace
  - component.labels

parameters:
  target_name: labels
  key: ${invalid}               # INVALID REFERENCE
```

## BEFORE (duplicate error)

```
kapitan inventory --inventory-backend=reclass
Inventory reclass error: -> labels
   Cannot resolve ${invalid}, at key, in yaml_fs:///src/inventory/targets/labels.yml
-> labels
   Cannot resolve ${invalid}, at key, in yaml_fs:///src/inventory/targets/labels.yml


kapitan inventory --inventory-backend=reclass-rs
Reclass-rs error: Error while rendering inventory: Error rendering node labels: While resolving references: lookup error for reference '${invalid}' in parameter 'key': key 'invalid' not found
Error while rendering inventory: Error rendering node labels: While resolving references: lookup error for reference '${invalid}' in parameter 'key': key 'invalid' not found
```

## AFTER 

```
kapitan inventory --inventory-backend=reclass
Inventory reclass error: -> labels
   Cannot resolve ${invalid}, at key, in yaml_fs:///src/inventory/targets/labels.yml


kapitan inventory --inventory-backend=reclass-rs
Reclass-rs error: Error while rendering inventory: Error rendering node labels: While resolving references: lookup error for reference '${invalid}' in parameter 'key': key 'invalid' not found
```