### PR TITLE
Upgrade go version used in Dockerfile to 1.24.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN python -m venv $VIRTUAL_ENV \
     && pip install --upgrade pip yq wheel poetry==$POETRY_VERSION
 
 # Install Go (for go-jsonnet)
-RUN curl -fsSL -o go.tar.gz https://go.dev/dl/go1.23.2.linux-${TARGETARCH}.tar.gz \
+RUN curl -fsSL -o go.tar.gz https://go.dev/dl/go1.24.2.linux-${TARGETARCH}.tar.gz \
     && tar -C /usr/local -xzf go.tar.gz \
     && rm go.tar.gz
 


### PR DESCRIPTION
## Context

In our project using kapitan, we have poor go-jsonnet performance. After some investigation, I think it could be linked to the go version used to build it. For example, on my M1 Pro machine, the build time decreased from 53 seconds to 24 seconds when upgrading from Go 1.23.2 to 1.23.8.

<details>
  <summary>Detailed Benchmark Results</summary>
  
  ```
Testing 1.23.2
Rendered inventory (9.43s): discovered 9 targets.
Compiling 9/9 targets using 8 concurrent processes: (8 CPU detected)
[...]
Compiled 9 targets in 50.32s
[...]    0.02s user 0.02s system 0% cpu 1:01.93 total

Testing 1.23.3
Rendered inventory (9.69s): discovered 9 targets.
Compiling 9/9 targets using 8 concurrent processes: (8 CPU detected)
[...]
Compiled 9 targets in 46.50s
[...]    0.02s user 0.02s system 0% cpu 59.375 total

Testing 1.23.8
Rendered inventory (9.21s): discovered 9 targets.
Compiling 9/9 targets using 8 concurrent processes: (8 CPU detected)
[...]
Compiled 9 targets in 12.60s
[...]    0.02s user 0.01s system 0% cpu 23.856 total

Testing 1.24.2
Rendered inventory (9.80s): discovered 9 targets.
Compiling 9/9 targets using 8 concurrent processes: (8 CPU detected)
[...]
Compiled 9 targets in 12.72s
[...]    0.01s user 0.01s system 0% cpu 24.705 total
```
</details>

As our project is jsonnet-heavy with a lot of fold-left and recursion, I would not expect such an improvement for everyone.

## Proposed Changes

Upgrade go version used in Dockerfile to 1.24.2, as I don't see reasons to not use the last version (1.24 is out since February, 1.23 will be EOL in August) but I could change the PR to upgrade to 1.23.8 if preferred by the maintainers. 
