### PR TITLE
Add missing classifier for Python 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 license = "Apache-2.0"
 version = "0.34.7"


### PR DESCRIPTION
Follow-up for #1338 where I forgot to update the `classifiers` list in `pyproject.toml` with an entry for Python 3.13
